### PR TITLE
Unix socket factory

### DIFF
--- a/static_pool.go
+++ b/static_pool.go
@@ -130,6 +130,28 @@ func (p *StaticPool) Exec(rqs *Payload) (rsp *Payload, err error) {
 	return rsp, nil
 }
 
+// Restart all underlying workers (but let them to complete the task).
+func (p *StaticPool) Restart() {
+	p.tasks.Wait()
+
+	var wg sync.WaitGroup
+	for i := uint64(0); i < p.cfg.NumWorkers; i++ {
+		w, err := p.allocateWorker()
+		if err != nil {
+			continue
+		}
+
+		wg.Add(1)
+		go func(w *Worker) {
+			defer wg.Done()
+
+			p.replaceWorker(w, "restart worker")
+		}(w)
+	}
+
+	wg.Wait()
+}
+
 // Destroy all underlying workers (but let them to complete the task).
 func (p *StaticPool) Destroy() {
 	p.tasks.Wait()
@@ -190,7 +212,7 @@ func (p *StaticPool) destroyWorker(w *Worker) {
 	p.muw.Lock()
 	for i, wc := range p.workers {
 		if wc == w {
-			p.workers = p.workers[:i+1]
+			p.workers = append(p.workers[:i], p.workers[i+1:]...)
 			break
 		}
 	}

--- a/tests/client.php
+++ b/tests/client.php
@@ -21,8 +21,13 @@ switch ($goridge) {
         break;
 
     case "unix":
+        $sockFile = "sock.unix";
+        if (!empty($argv[3]) && $argv[3] == "withpid") {
+            $sockFile = $sockFile . "." . getmypid();
+        }
+
         $relay = new Goridge\SocketRelay(
-            "sock.unix",
+            $sockFile,
             null,
             Goridge\SocketRelay::SOCK_UNIX
         );

--- a/unix_socket_factory.go
+++ b/unix_socket_factory.go
@@ -54,11 +54,11 @@ func (f *UnixSocketFactory) SpawnWorker(cmd *exec.Cmd) (w *Worker, err error) {
 	socketFile := fmt.Sprintf("%s.%d", f.file, *w.Pid)
 
 	os.Remove(socketFile)
-        f.ls, err = net.Listen("unix", socketFile)
+	f.ls, err = net.Listen("unix", socketFile)
 
-        if err != nil {
-                return nil, err
-        }
+	if err != nil {
+		return nil, err
+	}
 
 	go f.listen()
 

--- a/unix_socket_factory.go
+++ b/unix_socket_factory.go
@@ -55,6 +55,7 @@ func (f *UnixSocketFactory) SpawnWorker(cmd *exec.Cmd) (w *Worker, err error) {
 	if err != nil {
 		return nil, err
 	}
+	os.Chmod(socketFile, 0777)
 
 	go f.listen(ls)
 

--- a/unix_socket_factory.go
+++ b/unix_socket_factory.go
@@ -1,0 +1,138 @@
+package roadrunner
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spiral/goridge"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// UnixSocketFactory connects to external workers using socket server.
+type UnixSocketFactory struct {
+	// listens for incoming connections from underlying processes
+	ls net.Listener
+
+	// relay connection timeout
+	tout time.Duration
+
+	// protects socket mapping
+	mu sync.Mutex
+
+	// unix socket file
+	file string
+
+	// sockets which are waiting for process association
+	relays map[int]chan *goridge.SocketRelay
+}
+
+// NewUnixSocketFactory returns UnixSocketFactory attached to a given socket listener.
+// tout specifies for how long factory should serve for incoming relay connection
+func NewUnixSocketFactory(file string, tout time.Duration) *UnixSocketFactory {
+	f := &UnixSocketFactory{
+		file:   file,
+		tout:   tout,
+		relays: make(map[int]chan *goridge.SocketRelay),
+	}
+
+	return f
+}
+
+// SpawnWorker creates worker and connects it to appropriate relay or returns error
+func (f *UnixSocketFactory) SpawnWorker(cmd *exec.Cmd) (w *Worker, err error) {
+	if w, err = newWorker(cmd); err != nil {
+		return nil, err
+	}
+
+	if err := w.start(); err != nil {
+		return nil, errors.Wrap(err, "process error")
+	}
+
+	socketFile := fmt.Sprintf("%s.%d", f.file, *w.Pid)
+
+	os.Remove(socketFile)
+        f.ls, err = net.Listen("unix", socketFile)
+
+        if err != nil {
+                return nil, err
+        }
+
+	go f.listen()
+
+	rl, err := f.findRelay(w, f.tout)
+	if err != nil {
+		go func(w *Worker) { w.Kill() }(w)
+
+		if wErr := w.Wait(); wErr != nil {
+			err = errors.Wrap(wErr, err.Error())
+		}
+
+		return nil, errors.Wrap(err, "unable to connect to worker")
+	}
+
+	w.rl = rl
+	w.state.set(StateReady)
+
+	return w, nil
+}
+
+// listens for incoming socket connections
+func (f *UnixSocketFactory) listen() {
+	for {
+		conn, err := f.ls.Accept()
+		if err != nil {
+			return
+		}
+
+		rl := goridge.NewSocketRelay(conn)
+		if pid, err := fetchPID(rl); err == nil {
+			f.relayChan(pid) <- rl
+		}
+	}
+}
+
+// waits for worker to connect over socket and returns associated relay of timeout
+func (f *UnixSocketFactory) findRelay(w *Worker, tout time.Duration) (*goridge.SocketRelay, error) {
+	timer := time.NewTimer(tout)
+	for {
+		select {
+		case rl := <-f.relayChan(*w.Pid):
+			timer.Stop()
+			f.cleanChan(*w.Pid)
+			return rl, nil
+
+		case <-timer.C:
+			return nil, fmt.Errorf("relay timeout")
+
+		case <-w.waitDone:
+			timer.Stop()
+			f.cleanChan(*w.Pid)
+			return nil, fmt.Errorf("worker is gone")
+		}
+	}
+}
+
+// chan to store relay associated with specific Pid
+func (f *UnixSocketFactory) relayChan(pid int) chan *goridge.SocketRelay {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	rl, ok := f.relays[pid]
+	if !ok {
+		f.relays[pid] = make(chan *goridge.SocketRelay)
+		return f.relays[pid]
+	}
+
+	return rl
+}
+
+// deletes relay chan associated with specific Pid
+func (f *UnixSocketFactory) cleanChan(pid int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	delete(f.relays, pid)
+}

--- a/unix_socket_factory_test.go
+++ b/unix_socket_factory_test.go
@@ -1,0 +1,145 @@
+package roadrunner
+
+import (
+	"net"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UnixSocket_Start(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not supported on " + runtime.GOOS)
+	}
+
+	cmd := exec.Command("php", "tests/client.php", "echo", "unix", "withpid")
+
+	w, err := NewUnixSocketFactory("sock.unix", time.Minute).SpawnWorker(cmd)
+	assert.NoError(t, err)
+	assert.NotNil(t, w)
+
+	go func() {
+		assert.NoError(t, w.Wait())
+	}()
+
+	w.Stop()
+}
+
+func Test_UnixSocket_Echo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not supported on " + runtime.GOOS)
+	}
+
+	cmd := exec.Command("php", "tests/client.php", "echo", "unix", "withpid")
+
+	w, err := NewUnixSocketFactory("sock.unix", time.Minute).SpawnWorker(cmd)
+	go func() {
+		assert.NoError(t, w.Wait())
+	}()
+	defer w.Stop()
+
+	res, err := w.Exec(&Payload{Body: []byte("hello")})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.NotNil(t, res.Body)
+	assert.Nil(t, res.Context)
+
+	assert.Equal(t, "hello", res.String())
+}
+
+func Benchmark_UnixSocket_SpawnWorker_Stop(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("not supported on " + runtime.GOOS)
+	}
+
+	f := NewUnixSocketFactory("sock.unix", time.Minute)
+	for n := 0; n < b.N; n++ {
+		cmd := exec.Command("php", "tests/client.php", "echo", "unix", "withpid")
+
+		w, _ := f.SpawnWorker(cmd)
+		go func() {
+			if w.Wait() != nil {
+				b.Fail()
+			}
+		}()
+
+		w.Stop()
+	}
+}
+
+func Benchmark_UnixSocket_Worker_ExecEcho(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("not supported on " + runtime.GOOS)
+	}
+
+	cmd := exec.Command("php", "tests/client.php", "echo", "unix", "withpid")
+
+	w, _ := NewUnixSocketFactory("sock.unix", time.Minute).SpawnWorker(cmd)
+	go func() {
+		w.Wait()
+	}()
+	defer w.Stop()
+
+	for n := 0; n < b.N; n++ {
+		if _, err := w.Exec(&Payload{Body: []byte("hello")}); err != nil {
+			b.Fail()
+		}
+	}
+}
+
+func Benchmark_UnixSocket_Pool_ExecEcho(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("not supported on " + runtime.GOOS)
+	}
+
+	p, _ := NewPool(
+		func() *exec.Cmd { return exec.Command("php", "tests/client.php", "echo", "unix", "withpid") },
+		NewUnixSocketFactory("sock.unix", time.Minute),
+		Config{
+			NumWorkers:      8,
+			AllocateTimeout: time.Second,
+			DestroyTimeout:  time.Second,
+		},
+	)
+	defer p.Destroy()
+
+	for n := 0; n < b.N; n++ {
+		if _, err := p.Exec(&Payload{Body: []byte("hello")}); err != nil {
+			b.Fail()
+		}
+	}
+}
+
+func Benchmark_Unix_Pool_ExecEcho(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skip("not supported on " + runtime.GOOS)
+	}
+
+	ls, err := net.Listen("unix", "sock.unix")
+	if err == nil {
+		defer ls.Close()
+	} else {
+		b.Skip("socket is busy")
+	}
+
+	p, _ := NewPool(
+		func() *exec.Cmd { return exec.Command("php", "tests/client.php", "echo", "unix") },
+		NewSocketFactory(ls, time.Minute),
+		Config{
+			NumWorkers:      8,
+			AllocateTimeout: time.Second,
+			DestroyTimeout:  time.Second,
+		},
+	)
+	defer p.Destroy()
+
+	for n := 0; n < b.N; n++ {
+		if _, err := p.Exec(&Payload{Body: []byte("hello")}); err != nil {
+			b.Fail()
+		}
+	}
+}

--- a/worker.go
+++ b/worker.go
@@ -163,7 +163,7 @@ func (w *Worker) Exec(rqs *Payload) (rsp *Payload, err error) {
 	}
 
 	if w.state.Value() != StateReady {
-		return nil, fmt.Errorf("worker is not ready (%s)", w.state.Value())
+		return nil, fmt.Errorf("worker is not ready (%s)", w.state.String())
 	}
 
 	w.state.set(StateWorking)


### PR DESCRIPTION
I added new factory for unix sockets. It's useful for multi worker. I got 10% better performance vs default SocketFactory for unix socket. 

Example PHP Relay:
```
$relay = new Goridge\SocketRelay(
            '/tmp/go.sock.'.getmypid(),
            null,
            Goridge\SocketRelay::SOCK_UNIX
);
```