### PR TITLE
update vgo dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec
 	github.com/spf13/pflag v1.0.1
 	github.com/spf13/viper v1.0.2
-	github.com/spiral/goridge v1.0.4
+	github.com/spiral/goridge v0.0.0-20180607130832-0351012be508
 	golang.org/x/crypto v0.0.0-20180614221331-a8fb68e7206f
 	golang.org/x/sys v0.0.0-20180615093615-8014b7b116a6
 	golang.org/x/text v0.3.0


### PR DESCRIPTION
update vgo dependency `github.com/spiral/goridge` to recently release v2.1.2, because v1.4.1 is too old, when execute `make` command to build the application, there are some error

    # github.com/spiral/roadrunner/service/rpc
    service/rpc/service.go:70:25: undefined: goridge.NewCodec
    service/rpc/service.go:121:32: undefined: goridge.NewClientCodec
    # github.com/spiral/roadrunner
    ./worker.go:50:5: undefined: goridge.Relay
    make: *** [all] Error 2