### PR TITLE
[Feature] Decouple Diactoros from PSR7Client::acceptRequest() via PSR-17 HTTP factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   "require": {
     "php": "^7.0",
     "http-interop/http-factory-diactoros": "^1.0",
+    "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
     "spiral/goridge": "^2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
   ],
   "require": {
     "php": "^7.0",
-    "spiral/goridge": "^2.0",
+    "http-interop/http-factory-diactoros": "^1.0",
     "psr/http-message": "^1.0",
-    "zendframework/zend-diactoros": "^1.7"
+    "spiral/goridge": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -107,10 +107,7 @@ class PSR7Client
         if ($ctx['parsed']) {
             $request = $request->withParsedBody(json_decode($body, true));
         } else if ($body !== null) {
-            $bodyStream = $this->streamFactory->createStream($body);
-            $bodyStream->write($body);
-
-            $request = $request->withBody($bodyStream);
+            $request = $request->withBody($this->streamFactory->createStream($body));
         }
 
         return $request;
@@ -172,9 +169,11 @@ class PSR7Client
                 continue;
             }
 
-            $stream = UPLOAD_ERR_OK === $f['error'] ?
-                $this->streamFactory->createStreamFromFile($f['tmpName']) :
-                $this->streamFactory->createStream();
+            if (UPLOAD_ERR_OK === $f['error']) {
+                $stream = $this->streamFactory->createStreamFromFile($f['tmpName']);
+            } else {
+                $stream = $this->streamFactory->createStream();
+            }
 
             $result[$index] = $this->uploadsFactory->createUploadedFile(
                 $stream,

--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -7,9 +7,12 @@
 
 namespace Spiral\RoadRunner;
 
+use Http\Factory\Diactoros;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
 
 /**
  * Manages PSR-7 request and response.
@@ -17,16 +20,41 @@ use Zend\Diactoros;
 class PSR7Client
 {
     /**
-     * @varWorker
+     * @var Worker
      */
     private $worker;
 
     /**
-     * @param Worker $worker
+     * @var ServerRequestFactoryInterface
      */
-    public function __construct(Worker $worker)
-    {
+    private $requestFactory;
+
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    /**
+     * @var UploadedFileFactoryInterface
+     */
+    private $uploadsFactory;
+
+    /**
+     * @param Worker                             $worker
+     * @param ServerRequestFactoryInterface|null $requestFactory
+     * @param StreamFactoryInterface|null        $streamFactory
+     * @param UploadedFileFactoryInterface|null  $uploadsFactory
+     */
+    public function __construct(
+        Worker $worker,
+        ServerRequestFactoryInterface $requestFactory = null,
+        StreamFactoryInterface $streamFactory = null,
+        UploadedFileFactoryInterface $uploadsFactory = null
+    ) {
         $this->worker = $worker;
+        $this->requestFactory = $requestFactory ?? new Diactoros\ServerRequestFactory();
+        $this->streamFactory = $streamFactory ?? new Diactoros\StreamFactory();
+        $this->uploadsFactory = $uploadsFactory ?? new Diactoros\UploadedFileFactory();
     }
 
     /**
@@ -53,36 +81,39 @@ class PSR7Client
             return null;
         }
 
-        parse_str($ctx['rawQuery'], $query);
-
-        $bodyStream = 'php://input';
-        $parsedBody = null;
-        if ($ctx['parsed']) {
-            $parsedBody = json_decode($body, true);
-        } elseif ($body != null) {
-            $bodyStream = new Diactoros\Stream("php://memory", "rwb");
-            $bodyStream->write($body);
-        }
-
         $_SERVER = $this->configureServer($ctx);
 
-        $request = new Diactoros\ServerRequest(
-            $_SERVER,
-            $this->wrapUploads($ctx['uploads']),
-            $ctx['uri'],
+        $request = $this->requestFactory->createServerRequest(
             $ctx['method'],
-            $bodyStream,
-            $ctx['headers'],
-            $ctx['cookies'],
-            $query,
-            $parsedBody,
-            $ctx['protocol']
+            $ctx['uri'],
+            $_SERVER
         );
 
-        if (!empty($ctx['attributes'])) {
-            foreach ($ctx['attributes'] as $key => $value) {
-                $request = $request->withAttribute($key, $value);
-            }
+        parse_str($ctx['rawQuery'], $query);
+
+        $request = $request
+            ->withCookieParams($ctx['cookies'])
+            ->withProtocolVersion($ctx['protocol'])
+            ->withQueryParams($query)
+            ->withUploadedFiles($this->wrapUploads($ctx['uploads']));
+
+        foreach ($ctx['attributes'] as $name => $value) {
+            $request = $request->withAttribute($name, $value);
+        }
+
+        foreach ($ctx['headers'] as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        if ($body !== null) {
+            $bodyStream = $this->streamFactory->createStream($body);
+            $bodyStream->write($body);
+
+            $request = $request->withBody($bodyStream);
+        }
+
+        if ($ctx['parsed']) {
+            $request = $request->withParsedBody(json_decode($body, true));
         }
 
         return $request;
@@ -144,8 +175,8 @@ class PSR7Client
                 continue;
             }
 
-            $result[$index] = new Diactoros\UploadedFile(
-                $f['tmpName'],
+            $result[$index] = $this->uploadsFactory->createUploadedFile(
+                $this->streamFactory->createStreamFromFile($f['tmpName']),
                 $f['size'],
                 $f['error'],
                 $f['name'],


### PR DESCRIPTION
With this Pull Request `PSR7Client` now accepts `ServerRequestFactoryInterface`, `StreamFactoryInterface` and `UploadedFileFactoryInterface` instances in its constructor to customize the PSR-7 implementation returned by `PSR7Client::acceptRequest()`. The goal of this change is to simplify the integration of roadrunner with several other PSR-7 frameworks, such as Slim.

All three dependencies are optional. When they are not explicitly passed `http-interop/http-factory-diactoros` is used by default.

Everything should be backwards-compatible except for one tiny detail: calling `withProtocolVersion($ctx['protocol'])` on a Diactoros `ServerRequest` breaks several http tests. I haven't figured out what's the problem yet, for now this value is left hardcoded to `1.1`.

(FTR, the [initial discussion in Reddit](https://www.reddit.com/r/PHP/comments/9k7mh2/roadrunner_php_application_server_v124_released/e70s2cz/))