### PR TITLE
Clear the $_SERVER after every request

### DIFF
--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -73,6 +73,7 @@ class PSR7Client
             return null;
         }
 
+        $_SERVER = [];
         $_SERVER = $this->configureServer($ctx);
 
         $request = $this->requestFactory->createServerRequest(


### PR DESCRIPTION
The Server parameters should be cleaned after each run.

FIrst Request sends Cookies, the second not but they a still in $_SERVER available