### PR TITLE
Fix typo in naming of dep in static service

### DIFF
--- a/service/static/service.go
+++ b/service/static/service.go
@@ -1,7 +1,7 @@
 package static
 
 import (
-	rrttp "github.com/spiral/roadrunner/service/http"
+	rrhttp "github.com/spiral/roadrunner/service/http"
 	"net/http"
 	"path"
 )
@@ -20,7 +20,7 @@ type Service struct {
 
 // Init must return configure service and return true if service hasStatus enabled. Must return error in case of
 // misconfiguration. Services must not be used without proper configuration pushed first.
-func (s *Service) Init(cfg *Config, r *rrttp.Service) (bool, error) {
+func (s *Service) Init(cfg *Config, r *rrhttp.Service) (bool, error) {
 	if r == nil {
 		return false, nil
 	}


### PR DESCRIPTION
Small typo in service