### PR TITLE
Fix headers in _SERVER (Laravel integration fix)

### DIFF
--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -149,9 +149,9 @@ class PSR7Client
         foreach ($ctx['headers'] as $key => $value) {
             $key = strtoupper(str_replace('-', '_', $key));
             if (\in_array($key, array('CONTENT_TYPE', 'CONTENT_LENGTH'))) {
-                $_SERVER[$key] = implode(', ', $value);
+                $server[$key] = implode(', ', $value);
             } else {
-                $_SERVER['HTTP_' . $key] = implode(', ', $value);
+                $server['HTTP_' . $key] = implode(', ', $value);
             }
         }
 

--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -146,6 +146,7 @@ class PSR7Client
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';
 
+        $server['HTTP_USER_AGENT'] = '';
         foreach ($ctx['headers'] as $key => $value) {
             $key = strtoupper(str_replace('-', '_', $key));
             if (\in_array($key, array('CONTENT_TYPE', 'CONTENT_LENGTH'))) {

--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -146,9 +146,13 @@ class PSR7Client
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';
 
-        $server['HTTP_USER_AGENT'] = '';
-        if (isset($ctx['headers']['User-Agent'][0])) {
-            $server['HTTP_USER_AGENT'] = $ctx['headers']['User-Agent'][0];
+        foreach ($ctx['headers'] as $key => $value) {
+            $key = strtoupper(str_replace('-', '_', $key));
+            if (\in_array($key, array('CONTENT_TYPE', 'CONTENT_LENGTH'))) {
+                $_SERVER[$key] = implode(', ', $value);
+            } else {
+                $_SERVER['HTTP_' . $key] = implode(', ', $value);
+            }
         }
 
         return $server;

--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -32,6 +32,8 @@ class PSR7Client
     /*** @var UploadedFileFactoryInterface */
     private $uploadsFactory;
 
+    private $originalServer = [];
+
     /** @var array Valid values for HTTP protocol version */
     private static $allowedVersions = ['1.0', '1.1', '2',];
 
@@ -51,6 +53,7 @@ class PSR7Client
         $this->requestFactory = $requestFactory ?? new Diactoros\ServerRequestFactory();
         $this->streamFactory = $streamFactory ?? new Diactoros\StreamFactory();
         $this->uploadsFactory = $uploadsFactory ?? new Diactoros\UploadedFileFactory();
+        $this->originalServer = $_SERVER;
     }
 
     /**
@@ -129,6 +132,8 @@ class PSR7Client
             $response->getBody()->__toString(),
             json_encode(['status' => $response->getStatusCode(), 'headers' => $headers])
         );
+
+        $_SERVER = $this->originalServer;
     }
 
     /**
@@ -140,7 +145,7 @@ class PSR7Client
      */
     protected function configureServer(array $ctx): array
     {
-        $server = $_SERVER;
+        $server = $this->originalServer;
         $server['REQUEST_TIME'] = time();
         $server['REQUEST_TIME_FLOAT'] = microtime(true);
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';


### PR DESCRIPTION
Resolves #60 

After investigation of Latavel behavior, I found that Laravel and Symfony working in some places with headers as _SERVER params with HTTP_ prefix. 
Some people even recommended using _SERVER to retrieve headers (https://stackoverflow.com/questions/541430/how-do-i-read-any-request-header-in-php).

This request writes all headers to $server param, so SF and Laravel can access it. 