### PR TITLE
Raw HTTP client (HttpClient), PSR7Client now depends on HttpClient

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -52,7 +52,7 @@ class HttpClient
      *     key MUST be a header name, and each value MUST be an array of strings
      *     for that header.
      */
-    public function respond($status, $body, $headers = [])
+    public function respond(int $status, string $body, $headers = [])
     {
         if (empty($headers)) {
             // this is required to represent empty header set as map and not as array

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Spiral\RoadRunner;
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Spiral\RoadRunner;
+
+class HttpClient
+{
+    /** @var Worker */
+    private $worker;
+
+    /**
+     * @param Worker $worker
+     */
+    public function __construct(Worker $worker)
+    {
+        $this->worker = $worker;
+    }
+
+    /**
+     * @return Worker
+     */
+    public function getWorker(): Worker
+    {
+        return $this->worker;
+    }
+
+    /**
+     * @return array|null Request information as ['ctx'=>[], 'body'=>string] or null if termination request or invalid context.
+     */
+    public function acceptRequest()
+    {
+        $body = $this->getWorker()->receive($ctx);
+        if (empty($body) && empty($ctx)) {
+            // termination request
+            return null;
+        }
+
+        if (empty($ctx = json_decode($ctx, true))) {
+            // invalid context
+            return null;
+        }
+
+        return ['ctx' => $ctx, 'body' => $body];
+    }
+
+    /**
+     * Send response to the application server.
+     *
+     * @param int $status Http status code
+     * @param string $body Body of response
+     * @param string[][] $headers An associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings
+     *     for that header.
+     */
+    public function respond($status, $body, $headers = [])
+    {
+        if (empty($headers)) {
+            // this is required to represent empty header set as map and not as array
+            $headers = new \stdClass();
+        }
+
+        $this->getWorker()->send(
+            $body,
+            json_encode(['status' => $status, 'headers' => $headers])
+        );
+    }
+}


### PR DESCRIPTION
Hi!

As partially discussed in #105 this is the first stage of removing PSR Deps and allowing to work directly with a raw request from RoadRunner and response.
This PR will allow creating more optimized Symfony and Laravel integrations.