### PR TITLE
Rename MaxRequest config param

### DIFF
--- a/cmd/rr/.rr.yaml
+++ b/cmd/rr/.rr.yaml
@@ -28,8 +28,9 @@ http:
     # ssl private key
     key:      server.key
 
-  # max POST request size, including file uploads in MB.
+  # max POST request size, including file uploads in MB. Deprecated: use `maxRequestSize` instead
   maxRequest: 200
+  maxRequestSize: 200
 
   # file upload configuration.
   uploads:

--- a/service/http/config.go
+++ b/service/http/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	// SSL defines https server options.
 	SSL SSLConfig
 
-	// MaxRequest specified max size for payload body in megabytes, set 0 to unlimited.
-	MaxRequest int64
+	// MaxRequestSize specified max size for payload body in megabytes, set 0 to unlimited.
+	MaxRequest     int64
+	MaxRequestSize int64
 
 	// Uploads configures uploads configuration.
 	Uploads *UploadsConfig
@@ -68,6 +69,7 @@ func (c *Config) Hydrate(cfg service.Config) error {
 		return err
 	}
 
+	c.mergeBackwardCompatibility()
 	c.Workers.UpscaleDurations()
 
 	return c.Valid()
@@ -114,4 +116,10 @@ func (c *Config) Valid() error {
 	}
 
 	return nil
+}
+
+func (c *Config) mergeBackwardCompatibility() {
+	if c.MaxRequestSize == 0 && c.MaxRequest != 0 {
+		c.MaxRequestSize = c.MaxRequest
+	}
 }

--- a/service/http/config.go
+++ b/service/http/config.go
@@ -17,8 +17,11 @@ type Config struct {
 	// SSL defines https server options.
 	SSL SSLConfig
 
+	// MaxRequest specified max size for payload body in megabytes, set 0 to unlimited.
+	// Deprecated: use `maxRequestSize` instead
+	MaxRequest int64
+
 	// MaxRequestSize specified max size for payload body in megabytes, set 0 to unlimited.
-	MaxRequest     int64
 	MaxRequestSize int64
 
 	// Uploads configures uploads configuration.
@@ -118,6 +121,7 @@ func (c *Config) Valid() error {
 	return nil
 }
 
+// Perform merge operations for deprecated params to provide backward compatibility
 func (c *Config) mergeBackwardCompatibility() {
 	if c.MaxRequestSize == 0 && c.MaxRequest != 0 {
 		c.MaxRequestSize = c.MaxRequest

--- a/service/http/config_test.go
+++ b/service/http/config_test.go
@@ -222,3 +222,54 @@ func Test_Config_InvalidAddress(t *testing.T) {
 
 	assert.Error(t, cfg.Valid())
 }
+
+func Test_Config_MergeBackwardCompatibility_MaxRequestSize(t *testing.T) {
+	c := newTestBackwardCompatibilityConfig()
+	cfg := mockCfg{cfg: `{"maxRequestSize":512}`}
+	assert.NoError(t, c.Valid())
+	assert.NoError(t, c.Hydrate(&cfg))
+	assert.Equal(t, int64(512), int64(c.MaxRequestSize))
+
+	c = newTestBackwardCompatibilityConfig()
+	cfg = mockCfg{cfg: `{"maxRequestSize":256,"maxRequest":1024}`}
+	assert.NoError(t, c.Valid())
+	assert.NoError(t, c.Hydrate(&cfg))
+	assert.Equal(t, int64(256), int64(c.MaxRequestSize))
+
+	c = newTestBackwardCompatibilityConfig()
+	cfg = mockCfg{cfg: `{"maxRequestSize":256,"maxRequest":0}`}
+	assert.NoError(t, c.Valid())
+	assert.NoError(t, c.Hydrate(&cfg))
+	assert.Equal(t, int64(256), int64(c.MaxRequestSize))
+
+	c = newTestBackwardCompatibilityConfig()
+	cfg = mockCfg{cfg: `{"maxRequest":1024}`}
+	assert.NoError(t, c.Valid())
+	assert.NoError(t, c.Hydrate(&cfg))
+	assert.Equal(t, int64(1024), int64(c.MaxRequestSize))
+
+	c = newTestBackwardCompatibilityConfig()
+	cfg = mockCfg{cfg: `{"maxRequestSize":0,"maxRequest":1024}`}
+	assert.NoError(t, c.Valid())
+	assert.NoError(t, c.Hydrate(&cfg))
+	assert.Equal(t, int64(1024), int64(c.MaxRequestSize))
+}
+
+func newTestBackwardCompatibilityConfig() *Config {
+	return &Config{
+		Address: ":8080",
+		Uploads: &UploadsConfig{
+			Dir:    os.TempDir(),
+			Forbid: []string{".go"},
+		},
+		Workers: &roadrunner.ServerConfig{
+			Command: "php tests/client.php echo pipes",
+			Relay:   "pipes",
+			Pool: &roadrunner.Config{
+				NumWorkers:      1,
+				AllocateTimeout: time.Second,
+				DestroyTimeout:  time.Second,
+			},
+		},
+	}
+}

--- a/service/http/config_test.go
+++ b/service/http/config_test.go
@@ -31,8 +31,8 @@ func Test_Config_Hydrate_Error2(t *testing.T) {
 
 func Test_Config_Valid(t *testing.T) {
 	cfg := &Config{
-		Address:    ":8080",
-		MaxRequest: 1024,
+		Address:        ":8080",
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -58,7 +58,7 @@ func Test_Config_Valid_SSL(t *testing.T) {
 			Cert: "fixtures/server.crt",
 			Key:  "fixtures/server.key",
 		},
-		MaxRequest: 1024,
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -87,7 +87,7 @@ func Test_Config_SSL_No_key(t *testing.T) {
 		SSL: SSLConfig{
 			Cert: "fixtures/server.crt",
 		},
-		MaxRequest: 1024,
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -112,7 +112,7 @@ func Test_Config_SSL_No_Cert(t *testing.T) {
 		SSL: SSLConfig{
 			Key: "fixtures/server.key",
 		},
-		MaxRequest: 1024,
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -133,8 +133,8 @@ func Test_Config_SSL_No_Cert(t *testing.T) {
 
 func Test_Config_NoUploads(t *testing.T) {
 	cfg := &Config{
-		Address:    ":8080",
-		MaxRequest: 1024,
+		Address:        ":8080",
+		MaxRequestSize: 1024,
 		Workers: &roadrunner.ServerConfig{
 			Command: "php tests/client.php echo pipes",
 			Relay:   "pipes",
@@ -151,8 +151,8 @@ func Test_Config_NoUploads(t *testing.T) {
 
 func Test_Config_NoWorkers(t *testing.T) {
 	cfg := &Config{
-		Address:    ":8080",
-		MaxRequest: 1024,
+		Address:        ":8080",
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -164,8 +164,8 @@ func Test_Config_NoWorkers(t *testing.T) {
 
 func Test_Config_NoPool(t *testing.T) {
 	cfg := &Config{
-		Address:    ":8080",
-		MaxRequest: 1024,
+		Address:        ":8080",
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -186,8 +186,8 @@ func Test_Config_NoPool(t *testing.T) {
 
 func Test_Config_DeadPool(t *testing.T) {
 	cfg := &Config{
-		Address:    ":8080",
-		MaxRequest: 1024,
+		Address:        ":8080",
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},
@@ -203,8 +203,8 @@ func Test_Config_DeadPool(t *testing.T) {
 
 func Test_Config_InvalidAddress(t *testing.T) {
 	cfg := &Config{
-		Address:    "",
-		MaxRequest: 1024,
+		Address:        "",
+		MaxRequestSize: 1024,
 		Uploads: &UploadsConfig{
 			Dir:    os.TempDir(),
 			Forbid: []string{".go"},

--- a/service/http/handler.go
+++ b/service/http/handler.go
@@ -75,12 +75,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	// validating request size
-	if h.cfg.MaxRequest != 0 {
+	if h.cfg.MaxRequestSize != 0 {
 		if length := r.Header.Get("content-length"); length != "" {
 			if size, err := strconv.ParseInt(length, 10, 64); err != nil {
 				h.handleError(w, r, err, start)
 				return
-			} else if size > h.cfg.MaxRequest*1024*1024 {
+			} else if size > h.cfg.MaxRequestSize*1024*1024 {
 				h.handleError(w, r, errors.New("request body max size is exceeded"), start)
 				return
 			}

--- a/service/http/handler_test.go
+++ b/service/http/handler_test.go
@@ -32,7 +32,7 @@ func get(url string) (string, *http.Response, error) {
 func TestHandler_Echo(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -67,7 +67,7 @@ func TestHandler_Echo(t *testing.T) {
 func Test_HandlerErrors(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -94,7 +94,7 @@ func Test_HandlerErrors(t *testing.T) {
 func Test_Handler_JSON_error(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -123,7 +123,7 @@ func Test_Handler_JSON_error(t *testing.T) {
 func TestHandler_Headers(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -170,7 +170,7 @@ func TestHandler_Headers(t *testing.T) {
 func TestHandler_Empty_User_Agent(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -216,7 +216,7 @@ func TestHandler_Empty_User_Agent(t *testing.T) {
 func TestHandler_User_Agent(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -262,7 +262,7 @@ func TestHandler_User_Agent(t *testing.T) {
 func TestHandler_Cookies(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -313,7 +313,7 @@ func TestHandler_Cookies(t *testing.T) {
 func TestHandler_JsonPayload_POST(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -363,7 +363,7 @@ func TestHandler_JsonPayload_POST(t *testing.T) {
 func TestHandler_JsonPayload_PUT(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -409,7 +409,7 @@ func TestHandler_JsonPayload_PUT(t *testing.T) {
 func TestHandler_JsonPayload_PATCH(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -455,7 +455,7 @@ func TestHandler_JsonPayload_PATCH(t *testing.T) {
 func TestHandler_FormData_POST(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -513,7 +513,7 @@ func TestHandler_FormData_POST(t *testing.T) {
 func TestHandler_FormData_POST_Form_UrlEncoded_Charset(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -571,7 +571,7 @@ func TestHandler_FormData_POST_Form_UrlEncoded_Charset(t *testing.T) {
 func TestHandler_FormData_PUT(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -629,7 +629,7 @@ func TestHandler_FormData_PUT(t *testing.T) {
 func TestHandler_FormData_PATCH(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -687,7 +687,7 @@ func TestHandler_FormData_PATCH(t *testing.T) {
 func TestHandler_Multipart_POST(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -749,7 +749,7 @@ func TestHandler_Multipart_POST(t *testing.T) {
 func TestHandler_Multipart_PUT(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -811,7 +811,7 @@ func TestHandler_Multipart_PUT(t *testing.T) {
 func TestHandler_Multipart_PATCH(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -873,7 +873,7 @@ func TestHandler_Multipart_PATCH(t *testing.T) {
 func TestHandler_Error(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -907,7 +907,7 @@ func TestHandler_Error(t *testing.T) {
 func TestHandler_Error2(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -941,7 +941,7 @@ func TestHandler_Error2(t *testing.T) {
 func TestHandler_Error3(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1,
+			MaxRequestSize: 1,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -986,7 +986,7 @@ func TestHandler_Error3(t *testing.T) {
 func TestHandler_ResponseDuration(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -1035,7 +1035,7 @@ func TestHandler_ResponseDuration(t *testing.T) {
 func TestHandler_ResponseDurationDelayed(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -1084,7 +1084,7 @@ func TestHandler_ResponseDurationDelayed(t *testing.T) {
 func TestHandler_ErrorDuration(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -1132,7 +1132,7 @@ func TestHandler_ErrorDuration(t *testing.T) {
 func BenchmarkHandler_Listen_Echo(b *testing.B) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},

--- a/service/http/rpc_test.go
+++ b/service/http/rpc_test.go
@@ -27,7 +27,7 @@ func Test_RPC(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -88,7 +88,7 @@ func Test_RPC_Unix(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -142,7 +142,7 @@ func Test_Workers(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -84,7 +84,7 @@ func Test_Service_Configure_Enable(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":8070",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -115,7 +115,7 @@ func Test_Service_Echo(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -168,7 +168,7 @@ func Test_Service_Env(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -220,7 +220,7 @@ func Test_Service_ErrorEcho(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -280,7 +280,7 @@ func Test_Service_Middleware(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -354,7 +354,7 @@ func Test_Service_Listener(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -398,7 +398,7 @@ func Test_Service_Error(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -427,7 +427,7 @@ func Test_Service_Error2(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -456,7 +456,7 @@ func Test_Service_Error3(t *testing.T) {
 	assert.Error(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -483,7 +483,7 @@ func Test_Service_Error4(t *testing.T) {
 	assert.Error(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
 			"address": "----",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []

--- a/service/http/uploads_test.go
+++ b/service/http/uploads_test.go
@@ -20,7 +20,7 @@ import (
 func TestHandler_Upload_File(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -81,7 +81,7 @@ func TestHandler_Upload_File(t *testing.T) {
 func TestHandler_Upload_NestedFile(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{},
@@ -142,7 +142,7 @@ func TestHandler_Upload_NestedFile(t *testing.T) {
 func TestHandler_Upload_File_NoTmpDir(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    "-----",
 				Forbid: []string{},
@@ -203,7 +203,7 @@ func TestHandler_Upload_File_NoTmpDir(t *testing.T) {
 func TestHandler_Upload_File_Forbids(t *testing.T) {
 	h := &Handler{
 		cfg: &Config{
-			MaxRequest: 1024,
+			MaxRequestSize: 1024,
 			Uploads: &UploadsConfig{
 				Dir:    os.TempDir(),
 				Forbid: []string{".go"},

--- a/service/static/service_test.go
+++ b/service/static/service_test.go
@@ -60,7 +60,7 @@ func Test_Files(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -113,7 +113,7 @@ func Test_Files_Disable(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -150,7 +150,7 @@ func Test_Files_Error(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -180,7 +180,7 @@ func Test_Files_Error2(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -210,7 +210,7 @@ func Test_Files_Forbid(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -247,7 +247,7 @@ func Test_Files_Always(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -284,7 +284,7 @@ func Test_Files_NotFound(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -321,7 +321,7 @@ func Test_Files_Dir(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []
@@ -358,7 +358,7 @@ func Test_Files_NotForbid(t *testing.T) {
 		httpCfg: `{
 			"enable": true,
 			"address": ":6029",
-			"maxRequest": 1024,
+			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
 				"forbid": []


### PR DESCRIPTION
Added `MaxRequestSize` param, the previous one is marked as deprecated,
now they are merged until next major release