### PR TITLE
Fix build issue on macOS

### DIFF
--- a/qbuild/src/Builder.php
+++ b/qbuild/src/Builder.php
@@ -137,12 +137,12 @@ final class Builder
     {
         $os = strtolower(PHP_OS);
 
-        if (strpos($os, 'win') !== false) {
-            return 'windows';
-        }
-
         if (strpos($os, 'darwin') !== false) {
             return 'darwin';
+        }
+
+        if (strpos($os, 'win') !== false) {
+            return 'windows';
         }
 
         return "linux";


### PR DESCRIPTION
# Issue

Built on macOS however windows binary `rr.exe` is generated.

# Summary

Change order of condition. OS name `darwin` also has `win` in it. `win` should be checked after `darwin`.