### PR TITLE
Correct limit service ID

### DIFF
--- a/service/limit/service.go
+++ b/service/limit/service.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ID defines controller service name.
-const ID = "constrain"
+const ID = "limit"
 
 // controllable defines the ability to attach rr controller.
 type controllable interface {


### PR DESCRIPTION
I've noticed that limiting functionality doesn't work as expected - rr simply ignores limit settings. I found out that the reason is the wrong `limit.ID` value. I tried to cover this case with test,  but I couldn't find similar tests and couldn't write such test from scratch.