### PR TITLE
fix wrong config path and not deleted empty files in bin/rr

### DIFF
--- a/bin/rr
+++ b/bin/rr
@@ -224,7 +224,7 @@ class RRHelper
         $progressBar = new ProgressBar($output);
         $progressBar->setFormat('verbose');
 
-        $zipFileName = tempnam('.', "rr_zip");
+        $zipFileName = 'rr_zip_'.random_int(0, 10000);
         if (RRHelper::getOSType() == 'linux') {
             $zipFileName .= '.tar.gz';
         }
@@ -296,7 +296,7 @@ class RRHelper
         }
 
         copy(
-            __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '.rr.yaml',
+            __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '.rr.yaml',
             $input->getOption('location') . DIRECTORY_SEPARATOR . '.rr.yaml'
         );
         $output->writeln('<info>Config file created!</info>');


### PR DESCRIPTION
1.If system is linux `tempnam` create empty file, but then created new file with `.tar.gz` extension (and not deleted after download)
2. Wrong path in init config command