### PR TITLE
Add file watcher for serve cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.0.0
+	github.com/radovskyb/watcher v1.0.7
 	github.com/shirou/gopsutil v2.17.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.3.0


### PR DESCRIPTION
Hi there,

If think about this small feature:
The `serve` method should be able to restart itself if a file is edited (only in `debug` and having a `source` option during the serve cmd).

What do you think about this idea?