### PR TITLE
Provide support for HTTP/2 trailers

### DIFF
--- a/service/http/response.go
+++ b/service/http/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"regexp"
+	"strings"
 
 	"github.com/spiral/roadrunner"
 )
@@ -84,9 +84,9 @@ func handleTrailers(h map[string][]string) map[string][]string {
 		return h
 	}
 
-	zp := regexp.MustCompile(` *, *`)
 	for _, tr := range trailers {
-		for _, n := range zp.Split(tr, -1) {
+		for _, n := range strings.Split(tr, ",") {
+			n = strings.Trim(n, "\t ")
 			if v, ok := h[n]; ok {
 				h["Trailer:"+n] = v
 

--- a/service/http/response_test.go
+++ b/service/http/response_test.go
@@ -3,10 +3,11 @@ package http
 import (
 	"bytes"
 	"errors"
-	"github.com/spiral/roadrunner"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/spiral/roadrunner"
+	"github.com/stretchr/testify/assert"
 )
 
 type testWriter struct {
@@ -15,6 +16,8 @@ type testWriter struct {
 	wroteHeader bool
 	code        int
 	err         error
+	pushErr     error
+	pushes      []string
 }
 
 func (tw *testWriter) Header() http.Header { return tw.h }
@@ -33,6 +36,12 @@ func (tw *testWriter) Write(p []byte) (int, error) {
 }
 
 func (tw *testWriter) WriteHeader(code int) { tw.wroteHeader = true; tw.code = code }
+
+func (tw *testWriter) Push(target string, opts *http.PushOptions) error {
+	tw.pushes = append(tw.pushes, target)
+
+	return tw.pushErr
+}
 
 func TestNewResponse_Error(t *testing.T) {
 	r, err := NewResponse(&roadrunner.Payload{Context: []byte(`invalid payload`)})
@@ -89,4 +98,37 @@ func TestNewResponse_StreamError(t *testing.T) {
 
 	w := &testWriter{h: http.Header(make(map[string][]string)), err: errors.New("error")}
 	assert.Error(t, r.Write(w))
+}
+
+func TestWrite_HandlesPush(t *testing.T) {
+	r, err := NewResponse(&roadrunner.Payload{
+		Context: []byte(`{"headers":{"http2-push":["/test.js"],"content-type":["text/html"]},"status": 200}`),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+	w := &testWriter{h: http.Header(make(map[string][]string))}
+	assert.NoError(t, r.Write(w))
+
+	assert.Nil(t, w.h["http2-push"])
+	assert.Equal(t, []string{"/test.js"}, w.pushes)
+}
+
+func TestWrite_HandlesTrailers(t *testing.T) {
+	r, err := NewResponse(&roadrunner.Payload{
+		Context: []byte(`{"headers":{"trailer":["foo, bar", "baz"],"foo":["test"],"bar":["demo"]},"status": 200}`),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+	w := &testWriter{h: http.Header(make(map[string][]string))}
+	assert.NoError(t, r.Write(w))
+
+	assert.Nil(t, w.h["trailer"])
+	assert.Nil(t, w.h["foo"])
+	assert.Nil(t, w.h["baz"])
+	assert.Equal(t, "test", w.h.Get("Trailer:foo"))
+	assert.Equal(t, "demo", w.h.Get("Trailer:bar"))
 }

--- a/service/http/response_test.go
+++ b/service/http/response_test.go
@@ -132,3 +132,20 @@ func TestWrite_HandlesTrailers(t *testing.T) {
 	assert.Equal(t, "test", w.h.Get("Trailer:foo"))
 	assert.Equal(t, "demo", w.h.Get("Trailer:bar"))
 }
+
+func TestWrite_HandlesHandlesWhitespacesInTrailer(t *testing.T) {
+	r, err := NewResponse(&roadrunner.Payload{
+		Context: []byte(
+			`{"headers":{"trailer":["foo\t,bar  ,    baz"],"foo":["a"],"bar":["b"],"baz":["c"]},"status": 200}`),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+	w := &testWriter{h: http.Header(make(map[string][]string))}
+	assert.NoError(t, r.Write(w))
+
+	assert.Equal(t, "a", w.h.Get("Trailer:foo"))
+	assert.Equal(t, "b", w.h.Get("Trailer:bar"))
+	assert.Equal(t, "c", w.h.Get("Trailer:baz"))
+}


### PR DESCRIPTION
Neither PHP nor PSR-7 do not natively support HTTP trailers. Golang provides support and this PR enables trailers emulation. When PHP sends a "Trailer" header in response, supplying a comma separated list of headers they will be converted by RoadRunner to HTTP/2 trailers.

Resolves #209 

Any feedback is appreciated :bowing_man: 