### PR TITLE
RR binary in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .git
 .gitignore
 .editorconfig
-.idea
 .github
 /src
 /tests

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.git
+.gitignore
+.editorconfig
+.idea
+.github
+/src
+/tests
+/bin
+composer.json

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,12 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
       - name: Build image
-        run: docker build -t roadrunner -f Dockerfile .
+        run: docker build -t rr:local -f Dockerfile .
 
       - name: Try to execute
-        run: docker run --rm roadrunner -v
+        run: docker run --rm rr:local -v

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -89,3 +89,18 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if:
+
+  image:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Build image
+        run: docker build -t roadrunner -f Dockerfile .
+
+      - name: Try to execute
+        run: docker run --rm roadrunner -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+- added `Dockerfile` for building RR binary file
+
 v1.5.2 (05.12.2019)
 -------------------
 - added support for symfony/console 5.0 by @coxa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 UNRELEASED
 ----------
-- added `Dockerfile` for building RR binary file
+- added `Dockerfile` for building RR binary file by [@tarampampam](https://github.com/tarampampam) (closes [issue #218](https://github.com/spiral/roadrunner/issues/218))
 
 v1.5.2 (05.12.2019)
 -------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /src
 WORKDIR /src
 
 RUN set -x \
-    && apk add --no-cache bash \
+    && apk add --no-cache bash git \
     && go version \
     && bash ./build.sh \
     && ./rr -v \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image page: <https://hub.docker.com/_/golang>
-FROM golang:1.13-alpine as builder
+FROM golang:1.12-alpine as builder
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Image page: <https://hub.docker.com/_/golang>
+FROM golang:1.13-alpine as builder
+
+COPY . /src
+
+WORKDIR /src
+
+RUN set -x \
+    && apk add --no-cache bash \
+    && go version \
+    && bash ./build.sh \
+    && ./rr -v \
+    && test -f ./.rr.yaml
+
+FROM alpine:latest
+
+LABEL \
+    org.label-schema.name="roadrunner" \
+    org.label-schema.description="High-performance PHP application server, load-balancer and process manager" \
+    org.label-schema.url="https://github.com/spiral/roadrunner" \
+    org.label-schema.vcs-url="https://github.com/spiral/roadrunner" \
+    org.label-schema.vendor="SpiralScout" \
+    org.label-schema.license="MIT" \
+    org.label-schema.schema-version="1.0"
+
+COPY --from=builder /src/rr /usr/bin/rr
+COPY --from=builder /src/.rr.yaml /etc/rr.yaml
+
+ENTRYPOINT ["/usr/bin/rr"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ composer require spiral/roadrunner
 $ ./vendor/bin/rr get-binary
 ```
 
-> For getting roadrunner binary file you can use our docker image: `spiral/roadrunner:latest` (more info can be found [here](https://hub.docker.com/r/spiral/roadrunner/))
+> For getting roadrunner binary file you can use our docker image: `spiral/roadrunner:X.X.X` (more information about image and tags can be found [here](https://hub.docker.com/r/spiral/roadrunner/))
 
 Example:
 --------

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $ composer require spiral/roadrunner
 $ ./vendor/bin/rr get-binary
 ```
 
+> For getting roadrunner binary file you can use our docker image: `spiral/roadrunner:latest` (more info can be found [here](https://hub.docker.com/r/spiral/roadrunner/))
+
 Example:
 --------
 


### PR DESCRIPTION
This PR closes #218

Added / changed:

- `.dockerignore` excludes unimportant files for building (docker context)
- `ci-build.yml` imcludes step for image building testing
- `Dockerfile` contains instructions for image building

Required steps after PR merging:

1. @spiralscout must register account on [hub.docker.com](https://hub.docker.com/)
1. [Create repository](https://hub.docker.com/repository/create) on docker.hub and setup:
![image](https://user-images.githubusercontent.com/7326800/71064501-0836b900-2191-11ea-9295-dcbfda3aa9f5.png)
1. Profit!
