### PR TITLE
Expose logging via RPC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - go test ./service/limit -race -v -coverprofile=limit.txt -covermode=atomic
   - go test ./service/headers -race -v -coverprofile=headers.txt -covermode=atomic
   - go test ./service/metrics -race -v -coverprofile=metrics.txt -covermode=atomic
+  - go test ./service/log -race -v -coverprofile=log.txt -covermode=atomic
   - go test ./service/health -race -v -coverprofile=health.txt -covermode=atomic
 
 after_success:
@@ -42,6 +43,7 @@ after_success:
   - ./codecov-bash -f limit.txt
   - ./codecov-bash -f headers.txt
   - ./codecov-bash -f metrics.txt
+  - ./codecov-bash -f log.txt
   - ./codecov-bash -f health.txt
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test:
 	go test -v -race -cover ./service/limit
 	go test -v -race -cover ./service/headers
 	go test -v -race -cover ./service/metrics
+	go test -v -race -cover ./service/log
 	go test -v -race -cover ./service/health
 lint:
 	go fmt ./...

--- a/cmd/rr/main.go
+++ b/cmd/rr/main.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	rr "github.com/spiral/roadrunner/cmd/rr/cmd"
+	"github.com/spiral/roadrunner/service/log"
 
 	// services (plugins)
 	"github.com/spiral/roadrunner/service/env"
@@ -49,6 +50,7 @@ func main() {
 	rr.Container.Register(static.ID, &static.Service{})
 	rr.Container.Register(limit.ID, &limit.Service{})
 	rr.Container.Register(health.ID, &health.Service{})
+	rr.Container.Register(log.ID, &log.Service{})
 
 	// you can register additional commands using cmd.CLI
 	rr.Execute()

--- a/cmd/rr/main.go
+++ b/cmd/rr/main.go
@@ -24,7 +24,6 @@ package main
 
 import (
 	rr "github.com/spiral/roadrunner/cmd/rr/cmd"
-	"github.com/spiral/roadrunner/service/log"
 
 	// services (plugins)
 	"github.com/spiral/roadrunner/service/env"
@@ -32,6 +31,7 @@ import (
 	"github.com/spiral/roadrunner/service/health"
 	"github.com/spiral/roadrunner/service/http"
 	"github.com/spiral/roadrunner/service/limit"
+	"github.com/spiral/roadrunner/service/log"
 	"github.com/spiral/roadrunner/service/metrics"
 	"github.com/spiral/roadrunner/service/rpc"
 	"github.com/spiral/roadrunner/service/static"
@@ -49,8 +49,8 @@ func main() {
 	rr.Container.Register(headers.ID, &headers.Service{})
 	rr.Container.Register(static.ID, &static.Service{})
 	rr.Container.Register(limit.ID, &limit.Service{})
-	rr.Container.Register(health.ID, &health.Service{})
 	rr.Container.Register(log.ID, &log.Service{})
+	rr.Container.Register(health.ID, &health.Service{})
 
 	// you can register additional commands using cmd.CLI
 	rr.Execute()

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
     "symfony/console": "^2.5.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-    "zendframework/zend-diactoros": "^1.3 || ^2.0"
+    "zendframework/zend-diactoros": "^1.3 || ^2.0",
+    "psr/log": "^1.1"
   },
   "require-dev": {
     "phpstan/phpstan": "~0.12"

--- a/service/log/rpc.go
+++ b/service/log/rpc.go
@@ -1,0 +1,38 @@
+package log
+
+import "github.com/sirupsen/logrus"
+
+type rpcServer struct {
+	l logrus.FieldLogger
+}
+
+// Entry that represent a log entry to send to the logrus logger
+type Entry struct {
+	Level   string
+	Message string
+	Fields  interface{}
+}
+
+// Log writes the entry on the registered logger.
+// Using "fatal" & "panic" levels exit the process.
+func (r *rpcServer) Log(entry Entry, result *bool) error {
+	l, err := logrus.ParseLevel(entry.Level)
+
+	if err != nil {
+		*result = false
+
+		return err
+	}
+
+	fields, ok := entry.Fields.(map[string]interface{})
+
+	if !ok && entry.Fields != nil {
+		fields = logrus.Fields{"data": entry.Fields}
+	}
+
+	r.l.WithFields(fields).Log(l, entry.Message)
+
+	*result = true
+
+	return nil
+}

--- a/service/log/rpc_test.go
+++ b/service/log/rpc_test.go
@@ -1,0 +1,110 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spiral/roadrunner/service"
+	"github.com/spiral/roadrunner/service/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestRpcServer_Log(t *testing.T) {
+	c, hook := initContainer()
+	err := c.Init(&testCfg{rpcCfg: `{"enable":true}`, httpCfg: `{}`})
+
+	require.NoError(t, err)
+
+	rpcSvc, status := c.Get(rpc.ID)
+	assert.Equal(t, service.StatusOK, status)
+
+	rpc, ok := rpcSvc.(*rpc.Service)
+
+	assert.True(t, ok)
+
+	go c.Serve()
+	defer c.Stop()
+
+	time.Sleep(time.Millisecond * 100)
+
+	client, err := rpc.Client()
+
+	assert.NoError(t, err)
+
+	t.Run("Simple log", func(t *testing.T) {
+		var response bool
+
+		err := client.Call("log.Log", Entry{
+			Level:   "warn",
+			Message: "message",
+		}, &response)
+
+		assert.NoError(t, err)
+
+		lastLog := hook.LastEntry()
+
+		assert.True(t, response)
+		if assert.NotNil(t, lastLog) {
+			assert.Equal(t, "message", lastLog.Message)
+			assert.Equal(t, logrus.WarnLevel, lastLog.Level)
+			assert.Empty(t, lastLog.Data)
+		}
+
+	})
+
+	t.Run("String as fields", func(t *testing.T) {
+		var response bool
+
+		err := client.Call("log.Log", Entry{
+			Level:   "trace",
+			Message: "message",
+			Fields:  "foo",
+		}, &response)
+
+		assert.NoError(t, err)
+
+		lastLog := hook.LastEntry()
+		assert.True(t, response)
+
+		if assert.NotNil(t, lastLog) {
+			assert.Equal(t, "message", lastLog.Message)
+			assert.Equal(t, logrus.TraceLevel, lastLog.Level)
+			assert.Equal(t, "foo", lastLog.Data["data"])
+		}
+	})
+
+	t.Run("Map as fields", func(t *testing.T) {
+		var response bool
+
+		err := client.Call("log.Log", Entry{
+			Level:   "error",
+			Message: "message",
+			Fields:  map[string]interface{}{"foo": 1},
+		}, &response)
+
+		assert.NoError(t, err)
+
+		lastLog := hook.LastEntry()
+		assert.True(t, response)
+		if assert.NotNil(t, lastLog) {
+			assert.Equal(t, "message", lastLog.Message)
+			assert.Equal(t, logrus.ErrorLevel, lastLog.Level)
+			assert.Equal(t, float64(1), lastLog.Data["foo"])
+		}
+	})
+
+	t.Run("Wrong level", func(t *testing.T) {
+		hook.Reset()
+
+		var response bool
+
+		err := client.Call("log.Log", Entry{
+			Level: "unknown",
+		}, &response)
+
+		assert.Error(t, err)
+		assert.False(t, response)
+		assert.Nil(t, hook.LastEntry())
+	})
+}

--- a/service/log/service.go
+++ b/service/log/service.go
@@ -1,0 +1,24 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spiral/roadrunner/service/rpc"
+)
+
+// ID declares the public service name
+const ID = "log"
+
+// Service to register the RPC server
+type Service struct{}
+
+// Init service.
+func (s *Service) Init(log logrus.FieldLogger, r *rpc.Service) (bool, error) {
+
+	if r != nil {
+		if err := r.Register("log", &rpcServer{log}); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/service/log/service_test.go
+++ b/service/log/service_test.go
@@ -1,0 +1,133 @@
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiral/roadrunner/service"
+	rrHttp "github.com/spiral/roadrunner/service/http"
+	"github.com/spiral/roadrunner/service/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestService(t *testing.T) {
+	c, hook := initContainer()
+	c.Register(rrHttp.ID, &rrHttp.Service{})
+
+	err := c.Init(&testCfg{
+		rpcCfg: `{"enable":true}`,
+		httpCfg: `{
+			"address": "localhost:2115",
+
+			"workers":{
+				"command": "php ../../tests/http/client.php log pipes",
+				"pool": {"numWorkers": 1}
+			}
+		}`,
+	})
+
+	go func() {
+		err := c.Serve()
+
+		require.NoError(t, err)
+	}()
+	defer c.Stop()
+
+	time.Sleep(300 * time.Millisecond)
+
+	assert.NoError(t, err)
+
+	tests := []struct {
+		psrLevel    string
+		logrusLevel string
+	}{
+		{"emergency", "error"},
+		{"alert", "error"},
+		{"critical", "error"},
+		{"error", "error"},
+		{"warning", "warning"},
+		{"notice", "info"},
+		{"info", "info"},
+		{"debug", "debug"},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("PSR %s level log with %s logrus level", test.psrLevel, test.logrusLevel), func(t *testing.T) {
+			hook.Reset()
+			res, err := get(fmt.Sprintf("http://localhost:2115/?level=%s", test.psrLevel))
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+				e := hook.LastEntry()
+				assert.NotNil(t, e)
+				assert.Equal(t, test.logrusLevel, e.Level.String())
+				assert.Equal(t, test.psrLevel, e.Data["psr_level"])
+			}
+		})
+	}
+
+	t.Run("With fields", func(t *testing.T) {
+		hook.Reset()
+		res, err := get("http://localhost:2115/?level=info&message=hello&fields[foo]=bar")
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+			e := hook.LastEntry()
+			assert.NotNil(t, e)
+			assert.Equal(t, logrus.InfoLevel, e.Level)
+			assert.Equal(t, "hello", e.Message)
+			assert.Equal(t, "bar", e.Data["foo"])
+		}
+	})
+}
+
+func initContainer() (service.Container, *test.Hook) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+
+	c := service.NewContainer(logger)
+	c.Register(rpc.ID, &rpc.Service{})
+	c.Register(ID, &Service{})
+
+	return c, hook
+}
+
+type testCfg struct {
+	rpcCfg  string
+	httpCfg string
+	target  string
+}
+
+func (cfg *testCfg) Get(name string) service.Config {
+
+	if name == rpc.ID {
+		return &testCfg{target: cfg.rpcCfg}
+	}
+	if name == rrHttp.ID {
+		return &testCfg{target: cfg.httpCfg}
+	}
+
+	return nil
+}
+
+func (cfg *testCfg) Unmarshal(out interface{}) error {
+	err := json.Unmarshal([]byte(cfg.target), out)
+	return err
+}
+
+// get request and return body
+func get(url string) (*http.Response, error) {
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	return r, err
+}

--- a/service/log/service_test.go
+++ b/service/log/service_test.go
@@ -9,7 +9,6 @@ import (
 	rrHttp "github.com/spiral/roadrunner/service/http"
 	"github.com/spiral/roadrunner/service/rpc"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 	"time"
@@ -31,11 +30,7 @@ func TestService(t *testing.T) {
 		}`,
 	})
 
-	go func() {
-		err := c.Serve()
-
-		require.NoError(t, err)
-	}()
+	go c.Serve()
 	defer c.Stop()
 
 	time.Sleep(300 * time.Millisecond)

--- a/src/RPCLogger.php
+++ b/src/RPCLogger.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Spiral\RoadRunner;
+
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Spiral\Goridge\RPC;
+
+final class RPCLogger implements LoggerInterface
+{
+    private const PSR_TO_LOGRUS_LEVELS = [
+        // levels above "error" causes logrus to os.exit() or panic()
+        LogLevel::EMERGENCY => "error",
+        LogLevel::ALERT => "error",
+        LogLevel::CRITICAL => "error",
+        LogLevel::ERROR => "error",
+        LogLevel::WARNING => "warning",
+        LogLevel::NOTICE => "info",
+        LogLevel::INFO => "info",
+        LogLevel::DEBUG => "debug",
+    ];
+
+    /**
+     * @var RPC
+     */
+    private $rpc;
+
+    public function __construct(RPC $rpc)
+    {
+        $this->rpc = $rpc;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function emergency($message, array $context = array())
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function alert($message, array $context = array())
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function critical($message, array $context = array())
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function notice($message, array $context = array())
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function info($message, array $context = array())
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debug($message, array $context = array())
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (!isset(self::PSR_TO_LOGRUS_LEVELS[$level])) {
+            throw new InvalidArgumentException(sprintf("Invalid level '%s': only constants of '%s' are allowed", $level, LogLevel::class));
+        }
+
+        $context['psr_level'] = $level;
+
+        $this->rpc->call("log.Log", [
+            "message" => $message,
+            "level" => self::PSR_TO_LOGRUS_LEVELS[$level],
+            "fields" => $context,
+        ]);
+    }
+}

--- a/tests/http/log.php
+++ b/tests/http/log.php
@@ -1,0 +1,21 @@
+<?php
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use Spiral\Goridge\RPC;
+use Spiral\Goridge\SocketRelay;
+use Spiral\RoadRunner\RPCLogger;
+
+function handleRequest(ServerRequestInterface $req, ResponseInterface $resp): ResponseInterface
+{
+    $rpc = new RPC(new SocketRelay("127.0.0.1", 6001));
+    $logger = new RPCLogger($rpc);
+
+    $level = $req->getQueryParams()['level'] ?? 'warning';
+    $message = $req->getQueryParams()['message'] ?? 'default message';
+    $context = (array) ($req->getQueryParams()['fields'] ?? []);
+
+    $logger->log($level, $message, $context);
+
+    return $resp->withStatus(201);
+}


### PR DESCRIPTION
Hi,

This PR introduce logging capabilities for workers via RPC.

I know users can already logs by printing on `stderr`, but logs always appears with a `WARNING` level. It could be a great addition to be able to control log levels and fields.

This could make logs aggregations in containerised environment easier as apps could log directly on the container `stdout`.