### PR TITLE
Adding REQUEST_METHOD to $_SERVER

### DIFF
--- a/src/PSR7Client.php
+++ b/src/PSR7Client.php
@@ -138,6 +138,7 @@ class PSR7Client
         $server['REQUEST_TIME'] = time();
         $server['REQUEST_TIME_FLOAT'] = microtime(true);
         $server['REMOTE_ADDR'] = $ctx['attributes']['ipAddress'] ?? $ctx['remoteAddr'] ?? '127.0.0.1';
+        $server['REQUEST_METHOD'] = $ctx['method'];
 
         $server['HTTP_USER_AGENT'] = '';
         foreach ($ctx['headers'] as $key => $value) {


### PR DESCRIPTION
Related issue: #226 

Additionally, makes the coverage of documented $_SERVER values more complete per [PHP $_SERVER documentation](https://www.php.net/manual/en/reserved.variables.server.php).