### PR TITLE
BUGFIX: deadlock on timer update in error buffer

### DIFF
--- a/error_buffer.go
+++ b/error_buffer.go
@@ -92,8 +92,8 @@ func (eb *errBuffer) Len() int {
 func (eb *errBuffer) Write(p []byte) (int, error) {
 	eb.mu.Lock()
 	eb.buf = append(eb.buf, p...)
-	eb.update <- nil
 	eb.mu.Unlock()
+	eb.update <- nil
 
 	return len(p), nil
 }


### PR DESCRIPTION
Between lines 93-95 timer(`eb.wait`) can emit event and its `select` case will cause deadlock, because will can't(`select` wil be blocked) be able to read event from channel `eb.update`

example: https://play.golang.org/p/KuLEm4qnwSn