### PR TITLE
[Petition] Restore static builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,4 +47,4 @@ if [ "$1" == "all" ]; then
 	exit
 fi
 
-go build -ldflags "$LDFLAGS" -o "$OD/rr" cmd/rr/main.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS -extldflags '-static'" -o "$OD/rr" cmd/rr/main.go


### PR DESCRIPTION
Commit https://github.com/spiral/roadrunner/commit/02be3eec1d8323a16031e86c1ddcc5c52c440176 made between the 1.5.3 and 1.6.0 releases disabled static linking on the `build.sh` script, so the 1.6.x binaries distributed through the GH Releases page are tied to glibc and no longer run on musl-based Linux distros.

I don't know if there was a good reason for this change. In that case I'd start building the binaries myself, but I thought it could have been a mistake.


Thanks!