### PR TITLE
Update build.sh, support musl target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,4 +68,4 @@ if [ "$1" == "all" ]; then
   exit
 fi
 
-go build -ldflags "$LDFLAGS" -o "$OD/rr" cmd/rr/main.go
+CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o "$OD/rr" cmd/rr/main.go

--- a/build.sh
+++ b/build.sh
@@ -11,40 +11,61 @@ LDFLAGS="$LDFLAGS -X github.com/spiral/roadrunner/cmd/rr/cmd.BuildTime=$(date +%
 # remove debug info from binary as well as string and symbol tables
 LDFLAGS="$LDFLAGS -s"
 
-build(){
-	echo Packaging "$1" Build
-	bdir=roadrunner-${RR_VERSION}-$2-$3
-	rm -rf builds/"$bdir" && mkdir -p builds/"$bdir"
-	GOOS=$2 GOARCH=$3 ./build.sh
+build() {
+  echo Packaging "$1" Build
+  bdir=roadrunner-${RR_VERSION}-$2-$3
+  rm -rf builds/"$bdir" && mkdir -p builds/"$bdir"
+  GOOS=$2 GOARCH=$3 ./build.sh
 
-	if [ "$2" == "windows" ]; then
-		mv rr builds/"$bdir"/rr.exe
-	else
-		mv rr builds/"$bdir"
-	fi
+  if [ "$2" == "windows" ]; then
+    mv rr builds/"$bdir"/rr.exe
+  else
+    mv rr builds/"$bdir"
+  fi
 
-	cp README.md builds/"$bdir"
-	cp CHANGELOG.md builds/"$bdir"
-	cp LICENSE builds/"$bdir"
-	cd builds
+  cp README.md builds/"$bdir"
+  cp CHANGELOG.md builds/"$bdir"
+  cp LICENSE builds/"$bdir"
+  cd builds
 
-	if [ "$2" == "linux" ]; then
-		tar -zcf "$bdir".tar.gz "$bdir"
-	else
-		zip -r -q "$bdir".zip "$bdir"
-	fi
+  if [ "$2" == "linux" ]; then
+    tar -zcf "$bdir".tar.gz "$bdir"
+  else
+    zip -r -q "$bdir".zip "$bdir"
+  fi
 
-	rm -rf "$bdir"
-	cd ..
+  rm -rf "$bdir"
+  cd ..
+}
+
+# For musl build you should have musl-gcc installed. If not, please, use:
+# go build -a -ldflags "-linkmode external -extldflags '-static' -s"
+build_musl() {
+  echo Packaging "$2" Build
+  bdir=roadrunner-${RR_VERSION}-$1-$2-$3
+  rm -rf builds/"$bdir" && mkdir -p builds/"$bdir"
+  CC=musl-gcc GOARCH=amd64 go build -ldflags "$LDFLAGS" -o "$OD/rr" cmd/rr/main.go
+
+  mv rr builds/"$bdir"
+
+  cp README.md builds/"$bdir"
+  cp CHANGELOG.md builds/"$bdir"
+  cp LICENSE builds/"$bdir"
+  cd builds
+  zip -r -q "$bdir".zip "$bdir"
+
+  rm -rf "$bdir"
+  cd ..
 }
 
 if [ "$1" == "all" ]; then
-	rm -rf builds/
-	build "Windows" "windows" "amd64"
-	build "Mac" "darwin" "amd64"
-	build "Linux" "linux" "amd64"
-	build "FreeBSD" "freebsd" "amd64"
-	exit
+  rm -rf builds/
+  build "Windows" "windows" "amd64"
+  build "Mac" "darwin" "amd64"
+  build "Linux" "linux" "amd64"
+  build "FreeBSD" "freebsd" "amd64"
+  build_musl "unknown" "musl" "amd64"
+  exit
 fi
 
 go build -ldflags "$LDFLAGS" -o "$OD/rr" cmd/rr/main.go


### PR DESCRIPTION
Please, make sure, that musl-gcc is installed
Instead, use build type commented in build.sh
Ubuntu: `sudo apt-get install musl-tools`
ArchLinux: (this is community-driven distribution) `yay -S musl`
Verified successfully on latest musl-1.2.0 with Alpine Linux

Resolves #258 