### PR TITLE
Address already in use error

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
-        go: [1.12, 1.13]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        go: [1.12, 1.13, 1.14]
+        os: [ubuntu-latest, macOS-latest]
     env:
       GO111MODULE: on
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
-        go: [1.12, 1.13, 1.14]
+        go: [1.13, 1.14]
         os: [ubuntu-latest, macOS-latest]
     env:
       GO111MODULE: on

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build (PHP ${{ matrix.php }}, Go ${{ matrix.go }})
+    name: Build (PHP ${{ matrix.php }}, Go ${{ matrix.go }}, OS ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 1
 
       - name: Show versions
-        run: php -v && composer -V && go version
+        run: php -v ; composer -V ; go version
 
       - name: Debug if needed
         env:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
         go: [1.12, 1.13]
-        os: [ubuntu-latest, macOS-latest, windows, latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       GO111MODULE: on
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,99 +5,100 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build (PHP ${{ matrix.php }}, Go ${{ matrix.go }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
         go: [1.12, 1.13]
+        os: [ubuntu-latest, macOS-latest, windows, latest]
     env:
       GO111MODULE: on
     steps:
-    - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Set up PHP ${{ matrix.php }}
-      uses: shivammathur/setup-php@v1
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom
-        coverage: xdebug
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom
+          coverage: xdebug
 
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-    - name: Show versions
-      run: php -v && composer -V && go version
+      - name: Show versions
+        run: php -v && composer -V && go version
 
-    - name: Debug if needed
-      env:
-        DEBUG: ${{ secrets.DEBUG }}
-      run: if [[ "$DEBUG" == "true" ]]; then env && go env; fi
+      - name: Debug if needed
+        env:
+          DEBUG: ${{ secrets.DEBUG }}
+        run: if [[ "$DEBUG" == "true" ]]; then env && go env; fi
 
-    - name: Syntax check only (lint)
-      run: find ./src/ -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
+      - name: Syntax check only (lint)
+        run: find ./src/ -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
 
-    - name: Get Composer Cache Directory # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-      id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Get Composer Cache Directory # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-    - name: Cache dependencies # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-
+      - name: Cache dependencies # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-    - name: Install Composer dependencies
-      run: composer install --prefer-dist --no-interaction --no-suggest # --prefer-source
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-suggest # --prefer-source
 
-    - name: Analyze PHP sources
-      run: composer analyze
+      - name: Analyze PHP sources
+        run: composer analyze
 
-    - name: Install Go dependencies
-      run: go mod download
+      - name: Install Go dependencies
+        run: go mod download
 
-    - name: Download binary roadrunner
-      run: php ./bin/rr get-binary
+      - name: Download binary roadrunner
+        run: php ./bin/rr get-binary
 
-    - name: Run golang tests
-      run: |
-        go test -race -v -coverprofile=lib.txt -covermode=atomic
-        go test ./util -race -v -coverprofile=util.txt -covermode=atomic
-        go test ./service -race -v -coverprofile=service.txt -covermode=atomic
-        go test ./service/env -race -v -coverprofile=env.txt -covermode=atomic
-        go test ./service/rpc -race -v -coverprofile=rpc.txt -covermode=atomic
-        go test ./service/http -race -v -coverprofile=http.txt -covermode=atomic
-        go test ./service/static -race -v -coverprofile=static.txt -covermode=atomic
-        go test ./service/limit -race -v -coverprofile=limit.txt -covermode=atomic
-        go test ./service/headers -race -v -coverprofile=headers.txt -covermode=atomic
-        go test ./service/metrics -race -v -coverprofile=metrics.txt -covermode=atomic
-        go test ./service/health -race -v -coverprofile=health.txt -covermode=atomic
+      - name: Run golang tests
+        run: |
+          go test -race -v -coverprofile=lib.txt -covermode=atomic
+          go test ./util -race -v -coverprofile=util.txt -covermode=atomic
+          go test ./service -race -v -coverprofile=service.txt -covermode=atomic
+          go test ./service/env -race -v -coverprofile=env.txt -covermode=atomic
+          go test ./service/rpc -race -v -coverprofile=rpc.txt -covermode=atomic
+          go test ./service/http -race -v -coverprofile=http.txt -covermode=atomic
+          go test ./service/static -race -v -coverprofile=static.txt -covermode=atomic
+          go test ./service/limit -race -v -coverprofile=limit.txt -covermode=atomic
+          go test ./service/headers -race -v -coverprofile=headers.txt -covermode=atomic
+          go test ./service/metrics -race -v -coverprofile=metrics.txt -covermode=atomic
+          go test ./service/health -race -v -coverprofile=health.txt -covermode=atomic
 
-    - name: Run code coverage
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        if [[ "$CODECOV_TOKEN" != "" ]]; then
-          curl https://codecov.io/bash -o codecov-bash
-          chmod +x codecov-bash
-          ./codecov-bash -f lib.txt
-          ./codecov-bash -f util.txt
-          ./codecov-bash -f service.txt
-          ./codecov-bash -f env.txt
-          ./codecov-bash -f rpc.txt
-          ./codecov-bash -f http.txt
-          ./codecov-bash -f static.txt
-          ./codecov-bash -f limit.txt
-          ./codecov-bash -f headers.txt
-          ./codecov-bash -f metrics.txt
-          ./codecov-bash -f health.txt
-        fi
+      - name: Run code coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [[ "$CODECOV_TOKEN" != "" ]]; then
+            curl https://codecov.io/bash -o codecov-bash
+            chmod +x codecov-bash
+            ./codecov-bash -f lib.txt
+            ./codecov-bash -f util.txt
+            ./codecov-bash -f service.txt
+            ./codecov-bash -f env.txt
+            ./codecov-bash -f rpc.txt
+            ./codecov-bash -f http.txt
+            ./codecov-bash -f static.txt
+            ./codecov-bash -f limit.txt
+            ./codecov-bash -f headers.txt
+            ./codecov-bash -f metrics.txt
+            ./codecov-bash -f health.txt
+          fi
 
   golangci-check:
     name: runner / golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/spiral/goridge v2.1.4+incompatible
 	github.com/stretchr/testify v1.5.1
+	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	github.com/yookoala/gofast v0.4.0
 	golang.org/x/net v0.0.0-20200222125558-5a598a2470a0
 )

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6JcmhJgXi5E4b8Wg84ihbmUKp/GvSPEzc=
+github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yookoala/gofast v0.4.0 h1:dLBjghcsbbZNOEHN8N1X/gh9S6srmJed4WQfG7DlKwo=

--- a/pipe_factory_test.go
+++ b/pipe_factory_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os/exec"
 	"testing"
+	"time"
 )
 
 func Test_Pipe_Start(t *testing.T) {
@@ -108,8 +109,9 @@ func Test_Pipe_Broken(t *testing.T) {
 		assert.Contains(t, err.Error(), "undefined_function()")
 	}()
 	defer func() {
+		time.Sleep(time.Second)
 		err := w.Stop()
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	}()
 
 	res, err := w.Exec(&Payload{Body: []byte("hello")})

--- a/service/headers/service_test.go
+++ b/service/headers/service_test.go
@@ -259,13 +259,6 @@ func TestCORS_Pass(t *testing.T) {
 
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("error during the body closing: error %v", err)
-		}
-	}()
-
 	assert.Equal(t, "true", r.Header.Get("Access-Control-Allow-Credentials"))
 	assert.Equal(t, "*", r.Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "*", r.Header.Get("Access-Control-Allow-Origin"))
@@ -275,4 +268,9 @@ func TestCORS_Pass(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, r.StatusCode)
+
+	err = r.Body.Close()
+	if err != nil {
+		t.Errorf("error during the body closing: error %v", err)
+	}
 }

--- a/service/headers/service_test.go
+++ b/service/headers/service_test.go
@@ -46,7 +46,7 @@ func Test_RequestHeaders(t *testing.T) {
 		headers: `{"request":{"input": "custom-header"}}`,
 		httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6078",
 			"maxRequestSize": 1024,
 			"workers":{
 				"command": "php ../../tests/http/client.php header pipes",
@@ -68,7 +68,7 @@ func Test_RequestHeaders(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=value", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6078?hello=value", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -100,7 +100,7 @@ func Test_ResponseHeaders(t *testing.T) {
 		headers: `{"response":{"output": "output-header"},"request":{"input": "custom-header"}}`,
 		httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6079",
 			"maxRequestSize": 1024,
 			"workers":{
 				"command": "php ../../tests/http/client.php header pipes",
@@ -122,7 +122,7 @@ func Test_ResponseHeaders(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=value", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6079?hello=value", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -164,7 +164,7 @@ func TestCORS_OPTIONS(t *testing.T) {
 }`,
 		httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6379",
 			"maxRequestSize": 1024,
 			"workers":{
 				"command": "php ../../tests/http/client.php headers pipes",
@@ -186,7 +186,7 @@ func TestCORS_OPTIONS(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("OPTIONS", "http://localhost:6029", nil)
+	req, err := http.NewRequest("OPTIONS", "http://localhost:6379", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -232,7 +232,7 @@ func TestCORS_Pass(t *testing.T) {
 }`,
 		httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6672",
 			"maxRequestSize": 1024,
 			"workers":{
 				"command": "php ../../tests/http/client.php headers pipes",
@@ -254,7 +254,7 @@ func TestCORS_Pass(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6672", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)

--- a/service/http/fcgi_test.go
+++ b/service/http/fcgi_test.go
@@ -37,8 +37,7 @@ func Test_FCGI_Service_Echo(t *testing.T) {
 	s.(*Service).Stop()
 
 	go func() { assert.NoError(t, c.Serve()) }()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+	time.Sleep(time.Second * 1)
 
 	fcgiConnFactory := gofast.SimpleConnFactory("tcp", "0.0.0.0:6082")
 
@@ -56,6 +55,7 @@ func Test_FCGI_Service_Echo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 201, w.Result().StatusCode)
 	assert.Equal(t, "WORLD", string(body))
+	c.Stop()
 }
 
 func Test_FCGI_Service_Request_Uri(t *testing.T) {
@@ -83,7 +83,7 @@ func Test_FCGI_Service_Request_Uri(t *testing.T) {
 	s.(*Service).Stop()
 
 	go func() { assert.NoError(t, c.Serve()) }()
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Second * 1)
 
 	fcgiConnFactory := gofast.SimpleConnFactory("tcp", "0.0.0.0:6083")
 

--- a/service/http/fcgi_test.go
+++ b/service/http/fcgi_test.go
@@ -84,7 +84,6 @@ func Test_FCGI_Service_Request_Uri(t *testing.T) {
 
 	go func() { assert.NoError(t, c.Serve()) }()
 	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
 	fcgiConnFactory := gofast.SimpleConnFactory("tcp", "0.0.0.0:6083")
 
@@ -102,4 +101,5 @@ func Test_FCGI_Service_Request_Uri(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Result().StatusCode)
 	assert.Equal(t, "http://site.local/hello-world", string(body))
+	c.Stop()
 }

--- a/service/http/h2c_test.go
+++ b/service/http/h2c_test.go
@@ -52,16 +52,15 @@ func Test_Service_H2C(t *testing.T) {
 	req.Header.Add("Connection", "HTTP2-Settings")
 	req.Header.Add("HTTP2-Settings", "")
 
-	r, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("fail to close the Body: error %v", err)
-		}
-	}()
+	r, err2 := http.DefaultClient.Do(req)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
 
 	assert.Equal(t, "101 Switching Protocols", r.Status)
 
-	// will fail with h2c notice
+	err3 := r.Body.Close()
+	if err3 != nil {
+		t.Errorf("fail to close the Body: error %v", err3)
+	}
 }

--- a/service/http/rpc_test.go
+++ b/service/http/rpc_test.go
@@ -124,17 +124,29 @@ func Test_RPC_Unix(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	res, _, _ := get("http://localhost:6029")
-	assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res)
+	res, _, err := get("http://localhost:6029")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ss.rr.Workers() != nil && len(ss.rr.Workers()) > 0 {
+		assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res)
+	} else {
+		t.Fatal("no workers initialized")
+	}
 
 	cl, err := rs.Client()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	r := ""
 	assert.NoError(t, cl.Call("http.Reset", true, &r))
 	assert.Equal(t, "OK", r)
 
-	res2, _, _ := get("http://localhost:6029")
+	res2, _, err := get("http://localhost:6029")
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res2)
 	assert.NotEqual(t, res, res2)
 }

--- a/service/http/rpc_test.go
+++ b/service/http/rpc_test.go
@@ -55,10 +55,13 @@ func Test_RPC(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
-	res, _, _ := get("http://localhost:6029")
+	time.Sleep(time.Second)
+
+	res, _, err := get("http://localhost:6029")
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res)
 
 	cl, err := rs.Client()
@@ -68,9 +71,13 @@ func Test_RPC(t *testing.T) {
 	assert.NoError(t, cl.Call("http.Reset", true, &r))
 	assert.Equal(t, "OK", r)
 
-	res2, _, _ := get("http://localhost:6029")
+	res2, _, err := get("http://localhost:6029")
+	if err != nil {
+		t.Fatal()
+	}
 	assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res2)
 	assert.NotEqual(t, res, res2)
+	c.Stop()
 }
 
 func Test_RPC_Unix(t *testing.T) {

--- a/service/http/rpc_test.go
+++ b/service/http/rpc_test.go
@@ -128,21 +128,24 @@ func Test_RPC_Unix(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	res, _, err := get("http://localhost:6029")
 	if err != nil {
+		c.Stop()
 		t.Fatal(err)
 	}
 	if ss.rr.Workers() != nil && len(ss.rr.Workers()) > 0 {
 		assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res)
 	} else {
+		c.Stop()
 		t.Fatal("no workers initialized")
 	}
 
 	cl, err := rs.Client()
 	if err != nil {
+		c.Stop()
 		t.Fatal(err)
 	}
 
@@ -152,10 +155,12 @@ func Test_RPC_Unix(t *testing.T) {
 
 	res2, _, err := get("http://localhost:6029")
 	if err != nil {
+		c.Stop()
 		t.Fatal(err)
 	}
 	assert.Equal(t, strconv.Itoa(*ss.rr.Workers()[0].Pid), res2)
 	assert.NotEqual(t, res, res2)
+	c.Stop()
 }
 
 func Test_Workers(t *testing.T) {

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -146,26 +146,24 @@ func Test_Service_Echo(t *testing.T) {
 		}
 	}()
 	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
 	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("error closing the Body: error %v", err)
-		}
-	}()
-
 	b, err := ioutil.ReadAll(r.Body)
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 201, r.StatusCode)
 	assert.Equal(t, "WORLD", string(b))
+
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("error closing the Body: error %v", err2)
+	}
+	c.Stop()
 }
 
 func Test_Service_Env(t *testing.T) {

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -176,7 +176,7 @@ func Test_Service_Env(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6031",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -206,10 +206,10 @@ func Test_Service_Env(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	time.Sleep(time.Second * 1)
+
+	req, err := http.NewRequest("GET", "http://localhost:6031", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -227,6 +227,7 @@ func Test_Service_Env(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, r.StatusCode)
 	assert.Equal(t, "ENV_VALUE", string(b))
+	c.Stop()
 }
 
 func Test_Service_ErrorEcho(t *testing.T) {
@@ -238,7 +239,7 @@ func Test_Service_ErrorEcho(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6030",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -274,10 +275,10 @@ func Test_Service_ErrorEcho(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
+	time.Sleep(time.Second)
+
+	req, err := http.NewRequest("GET", "http://localhost:6030?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -297,6 +298,7 @@ func Test_Service_ErrorEcho(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 201, r.StatusCode)
 	assert.Equal(t, "WORLD", string(b))
+	c.Stop()
 }
 
 func Test_Service_Middleware(t *testing.T) {
@@ -308,7 +310,7 @@ func Test_Service_Middleware(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6032",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -352,7 +354,7 @@ func Test_Service_Middleware(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6032?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -370,7 +372,7 @@ func Test_Service_Middleware(t *testing.T) {
 		t.Errorf("error closing the Body: error %v", err)
 	}
 
-	req, err = http.NewRequest("GET", "http://localhost:6029/halt", nil)
+	req, err = http.NewRequest("GET", "http://localhost:6032/halt", nil)
 	assert.NoError(t, err)
 
 	r, err = http.DefaultClient.Do(req)
@@ -397,7 +399,7 @@ func Test_Service_Listener(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6033",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -446,7 +448,7 @@ func Test_Service_Error(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6034",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -475,7 +477,7 @@ func Test_Service_Error2(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6035",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -504,7 +506,7 @@ func Test_Service_Error3(t *testing.T) {
 
 	assert.Error(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6036",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -351,8 +351,7 @@ func Test_Service_Middleware(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+	time.Sleep(time.Second)
 
 	req, err := http.NewRequest("GET", "http://localhost:6032?hello=world", nil)
 	assert.NoError(t, err)
@@ -386,8 +385,10 @@ func Test_Service_Middleware(t *testing.T) {
 
 	err = r.Body.Close()
 	if err != nil {
+		c.Stop()
 		t.Errorf("error closing the Body: error %v", err)
 	}
+	c.Stop()
 }
 
 func Test_Service_Listener(t *testing.T) {

--- a/service/http/service_test.go
+++ b/service/http/service_test.go
@@ -115,7 +115,7 @@ func Test_Service_Echo(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"enable": true,
-			"address": ":6029",
+			"address": ":6536",
 			"maxRequestSize": 1024,
 			"uploads": {
 				"dir": ` + tmpDir() + `,
@@ -147,7 +147,7 @@ func Test_Service_Echo(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 100)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6536?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)

--- a/service/http/ssl_test.go
+++ b/service/http/ssl_test.go
@@ -109,8 +109,8 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
 	assert.NoError(t, err)
@@ -118,10 +118,7 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 	r, err := sslClient.Do(req)
 	assert.NoError(t, err)
 	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("fail to close the Body: error %v", err)
-		}
+
 	}()
 
 	assert.Nil(t, r.TLS)
@@ -132,6 +129,12 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 201, r.StatusCode)
 	assert.Equal(t, "WORLD", string(b))
+
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("fail to close the Body: error %v", err2)
+	}
+	c.Stop()
 }
 
 func Test_SSL_Service_Redirect(t *testing.T) {

--- a/service/http/ssl_test.go
+++ b/service/http/ssl_test.go
@@ -171,8 +171,8 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
 	assert.NoError(t, err)
@@ -180,10 +180,7 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 	r, err := sslClient.Do(req)
 	assert.NoError(t, err)
 	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("fail to close the Body: error %v", err)
-		}
+
 	}()
 
 	assert.NotNil(t, r.TLS)
@@ -194,6 +191,12 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 201, r.StatusCode)
 	assert.Equal(t, "WORLD", string(b))
+
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("fail to close the Body: error %v", err2)
+	}
+	c.Stop()
 }
 
 func Test_SSL_Service_Push(t *testing.T) {

--- a/service/http/ssl_test.go
+++ b/service/http/ssl_test.go
@@ -236,7 +236,7 @@ func Test_SSL_Service_Push(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	defer c.Stop()
 
-	req, err := http.NewRequest("GET", "https://localhost:6900?hello=world", nil)
+	req, err := http.NewRequest("GET", "https://localhost:6903?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := sslClient.Do(req)

--- a/service/http/ssl_test.go
+++ b/service/http/ssl_test.go
@@ -86,7 +86,7 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"address": ":6030",
 			"ssl": {
-				"port": 6900,
+				"port": 6901,
 				"key": "fixtures/server.key",
 				"cert": "fixtures/server.crt"
 			},
@@ -147,7 +147,7 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"address": ":6031",
 			"ssl": {
-				"port": 6900,
+				"port": 6902,
 				"redirect": true,
 				"key": "fixtures/server.key",
 				"cert": "fixtures/server.crt"
@@ -209,7 +209,7 @@ func Test_SSL_Service_Push(t *testing.T) {
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
 			"address": ":6032",
 			"ssl": {
-				"port": 6900,
+				"port": 6903,
 				"redirect": true,
 				"key": "fixtures/server.key",
 				"cert": "fixtures/server.crt"

--- a/service/http/ssl_test.go
+++ b/service/http/ssl_test.go
@@ -84,7 +84,7 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 	c.Register(ID, &Service{})
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
-			"address": ":6029",
+			"address": ":6030",
 			"ssl": {
 				"port": 6900,
 				"key": "fixtures/server.key",
@@ -112,7 +112,7 @@ func Test_SSL_Service_NoRedirect(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6030?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := sslClient.Do(req)
@@ -145,7 +145,7 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 	c.Register(ID, &Service{})
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
-			"address": ":6029",
+			"address": ":6031",
 			"ssl": {
 				"port": 6900,
 				"redirect": true,
@@ -174,7 +174,7 @@ func Test_SSL_Service_Redirect(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029?hello=world", nil)
+	req, err := http.NewRequest("GET", "http://localhost:6031?hello=world", nil)
 	assert.NoError(t, err)
 
 	r, err := sslClient.Do(req)
@@ -207,7 +207,7 @@ func Test_SSL_Service_Push(t *testing.T) {
 	c.Register(ID, &Service{})
 
 	assert.NoError(t, c.Init(&testCfg{httpCfg: `{
-			"address": ":6029",
+			"address": ":6032",
 			"ssl": {
 				"port": 6900,
 				"redirect": true,

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -147,7 +147,7 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 	}()
 
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 
 	lastPID := getPID(s)
 

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -376,8 +376,8 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 				c.Stop()
 				t.Errorf("error during sending the http request: error %v", err)
 			}
-			c.Stop()
 			assert.NotEqual(t, lastPID, getPID(s))
+			c.Stop()
 			return
 		default:
 			_, err := http.DefaultClient.Do(req)

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -391,6 +391,10 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 	}
 }
 func getPID(s interface{}) string {
-	w := s.(*rrhttp.Service).Server().Workers()[0]
-	return fmt.Sprintf("%v", *w.Pid)
+	if len(s.(*rrhttp.Service).Server().Workers()) > 0 {
+		w := s.(*rrhttp.Service).Server().Workers()[0]
+		return fmt.Sprintf("%v", *w.Pid)
+	} else {
+		panic("no workers")
+	}
 }

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -57,7 +57,7 @@ func Test_Service_PidEcho(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{
 		httpCfg: `{
-			"address": ":6029",
+			"address": ":7029",
 			"workers":{
 				"command": "php ../../tests/http/client.php pid pipes",
 				"pool": {"numWorkers": 1}
@@ -83,7 +83,7 @@ func Test_Service_PidEcho(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond * 100)
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:7029", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -113,7 +113,7 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{
 		httpCfg: `{
-			"address": ":6029",
+			"address": ":7030",
 			"workers":{
 				"command": "php ../../tests/http/client.php pid pipes",
 				"pool": {"numWorkers": 1}
@@ -151,7 +151,7 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 
 	lastPID := getPID(s)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:7030", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -165,7 +165,7 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 	<-captured
 
 	// clean state
-	req, err = http.NewRequest("GET", "http://localhost:6029?new", nil)
+	req, err = http.NewRequest("GET", "http://localhost:7030?new", nil)
 	assert.NoError(t, err)
 
 	_, err = http.DefaultClient.Do(req)
@@ -191,7 +191,7 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{
 		httpCfg: `{
-			"address": ":6029",
+			"address": ":7031",
 			"workers":{
 				"command": "php ../../tests/http/client.php pid pipes",
 				"pool": {"numWorkers": 1}
@@ -229,7 +229,7 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 
 	lastPID := getPID(s)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:7031", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -244,7 +244,7 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 	<-captured
 
 	// clean state
-	req, err = http.NewRequest("GET", "http://localhost:6029?new", nil)
+	req, err = http.NewRequest("GET", "http://localhost:7031?new", nil)
 	assert.NoError(t, err)
 
 	_, err = http.DefaultClient.Do(req)
@@ -269,7 +269,7 @@ func Test_Service_Listener_MaxExecTTL(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{
 		httpCfg: `{
-			"address": ":6029",
+			"address": ":7032",
 			"workers":{
 				"command": "php ../../tests/http/client.php stuck pipes",
 				"pool": {"numWorkers": 1}
@@ -304,7 +304,7 @@ func Test_Service_Listener_MaxExecTTL(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:7032", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
@@ -326,7 +326,7 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 
 	assert.NoError(t, c.Init(&testCfg{
 		httpCfg: `{
-			"address": ":6029",
+			"address": ":7033",
 			"workers":{
 				"command": "php ../../tests/http/client.php memleak pipes",
 				"pool": {"numWorkers": 1}
@@ -365,7 +365,7 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 
 	lastPID := getPID(s)
 
-	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
+	req, err := http.NewRequest("GET", "http://localhost:7033", nil)
 	assert.NoError(t, err)
 
 	for {

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -82,7 +82,7 @@ func Test_Service_PidEcho(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
 	assert.NoError(t, err)
 
@@ -225,7 +225,7 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 	}()
 
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 
 	lastPID := getPID(s)
 
@@ -302,7 +302,7 @@ func Test_Service_Listener_MaxExecTTL(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 
 	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
 	assert.NoError(t, err)
@@ -361,7 +361,7 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 
 	lastPID := getPID(s)
 

--- a/service/limit/service_test.go
+++ b/service/limit/service_test.go
@@ -81,26 +81,26 @@ func Test_Service_PidEcho(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
 
+	time.Sleep(time.Second)
 	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
 	assert.NoError(t, err)
 
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("error during the body closing: error %v", err)
-		}
-	}()
+
 
 	b, err := ioutil.ReadAll(r.Body)
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, getPID(s), string(b))
+
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("error during the body closing: error %v", err2)
+	}
+	c.Stop()
 }
 
 func Test_Service_ListenerPlusTTL(t *testing.T) {
@@ -145,8 +145,9 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+
+	time.Sleep(time.Second)
 
 	lastPID := getPID(s)
 
@@ -155,12 +156,7 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("error during the body closing: error %v", err)
-		}
-	}()
+
 
 	b, err := ioutil.ReadAll(r.Body)
 	assert.NoError(t, err)
@@ -176,6 +172,13 @@ func Test_Service_ListenerPlusTTL(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, lastPID, getPID(s))
+
+	c.Stop()
+
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("error during the body closing: error %v", err2)
+	}
 }
 
 func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
@@ -220,8 +223,9 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+
+	time.Sleep(time.Second)
 
 	lastPID := getPID(s)
 
@@ -230,12 +234,6 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	defer func() {
-		err := r.Body.Close()
-		if err != nil {
-			t.Errorf("error during the body closing: error %v", err)
-		}
-	}()
 
 	b, err := ioutil.ReadAll(r.Body)
 	assert.NoError(t, err)
@@ -253,6 +251,12 @@ func Test_Service_ListenerPlusIdleTTL(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, lastPID, getPID(s))
+
+	c.Stop()
+	err2 := r.Body.Close()
+	if err2 != nil {
+		t.Errorf("error during the body closing: error %v", err2)
+	}
 }
 
 func Test_Service_Listener_MaxExecTTL(t *testing.T) {
@@ -297,8 +301,8 @@ func Test_Service_Listener_MaxExecTTL(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	req, err := http.NewRequest("GET", "http://localhost:6029", nil)
 	assert.NoError(t, err)
@@ -308,6 +312,8 @@ func Test_Service_Listener_MaxExecTTL(t *testing.T) {
 	assert.Equal(t, 500, r.StatusCode)
 
 	<-captured
+
+	c.Stop()
 }
 
 func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
@@ -354,8 +360,8 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 			t.Errorf("error during the Serve: error %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	lastPID := getPID(s)
 
@@ -367,15 +373,20 @@ func Test_Service_Listener_MaxMemoryUsage(t *testing.T) {
 		case <-captured:
 			_, err := http.DefaultClient.Do(req)
 			if err != nil {
+				c.Stop()
 				t.Errorf("error during sending the http request: error %v", err)
 			}
+			c.Stop()
 			assert.NotEqual(t, lastPID, getPID(s))
 			return
 		default:
 			_, err := http.DefaultClient.Do(req)
 			if err != nil {
+				c.Stop()
 				t.Errorf("error during sending the http request: error %v", err)
 			}
+			c.Stop()
+			return
 		}
 	}
 }

--- a/service/reload/config_test.go
+++ b/service/reload/config_test.go
@@ -27,7 +27,7 @@ func Test_Config_Valid(t *testing.T) {
 func Test_Fake_ServiceConfig(t *testing.T) {
 	services := make(map[string]ServiceConfig)
 	cfg := &Config{
-		Interval: time.Second,
+		Interval: time.Microsecond,
 		Patterns: nil,
 		Services: services,
 	}

--- a/service/reload/watcher_test.go
+++ b/service/reload/watcher_test.go
@@ -129,7 +129,6 @@ func Test_Get_FileEvent(t *testing.T) {
 					panic("didn't handle event when write file2")
 				}
 				w.Stop()
-				return
 			}
 		}()
 	}()
@@ -224,7 +223,7 @@ func Test_FileExtensionFilter(t *testing.T) {
 			}
 		}()
 		w.Stop()
-		return
+		runtime.Goexit()
 	}()
 
 	err = w.StartPolling(time.Second)

--- a/service/rpc/config_test.go
+++ b/service/rpc/config_test.go
@@ -48,7 +48,7 @@ func TestConfig_Listener(t *testing.T) {
 	}()
 
 	assert.Equal(t, "tcp", ln.Addr().Network())
-	assert.Equal(t, "[::]:18001", ln.Addr().String())
+	assert.Equal(t, "0.0.0.0:18001", ln.Addr().String())
 }
 
 func TestConfig_ListenerUnix(t *testing.T) {

--- a/service/static/service_test.go
+++ b/service/static/service_test.go
@@ -90,11 +90,13 @@ func Test_Files(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
+
 
 	b, _, _ := get("http://localhost:6029/sample.txt")
 	assert.Equal(t, "sample", b)
+	c.Stop()
 }
 
 func Test_Disabled(t *testing.T) {
@@ -334,11 +336,12 @@ func Test_Files_NotFound(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	b, _, _ := get("http://localhost:6029/client.XXX?hello=world")
 	assert.Equal(t, "WORLD", b)
+	c.Stop()
 }
 
 func Test_Files_Dir(t *testing.T) {
@@ -376,11 +379,11 @@ func Test_Files_Dir(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+	time.Sleep(time.Second)
 
 	b, _, _ := get("http://localhost:6029/http?hello=world")
 	assert.Equal(t, "WORLD", b)
+	c.Stop()
 }
 
 func Test_Files_NotForbid(t *testing.T) {
@@ -418,11 +421,13 @@ func Test_Files_NotForbid(t *testing.T) {
 			t.Errorf("serve error: %v", err)
 		}
 	}()
-	time.Sleep(time.Millisecond * 100)
-	defer c.Stop()
+
+	time.Sleep(time.Second)
 
 	b, _, _ := get("http://localhost:6029/client.php")
 	assert.Equal(t, all("../../tests/client.php"), b)
+	assert.Equal(t, all("../../tests/client.php"), b)
+	c.Stop()
 }
 
 func tmpDir() string {

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -43,7 +43,7 @@ func Test_Tcp_Start(t *testing.T) {
 func Test_Tcp_StartCloseFactory(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9008")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 	} else {
 		t.Skip("socket is busy")
@@ -76,7 +76,7 @@ func Test_Tcp_StartCloseFactory(t *testing.T) {
 func Test_Tcp_StartError(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9009")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -102,7 +102,7 @@ func Test_Tcp_StartError(t *testing.T) {
 func Test_Tcp_Failboot(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9010")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err3 := ls.Close()
@@ -125,7 +125,7 @@ func Test_Tcp_Failboot(t *testing.T) {
 func Test_Tcp_Timeout(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9011")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -148,7 +148,7 @@ func Test_Tcp_Timeout(t *testing.T) {
 func Test_Tcp_Invalid(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9012")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -170,7 +170,7 @@ func Test_Tcp_Invalid(t *testing.T) {
 func Test_Tcp_Broken(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9013")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -207,7 +207,7 @@ func Test_Tcp_Broken(t *testing.T) {
 func Test_Tcp_Echo(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9014")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -428,7 +428,7 @@ func Test_Unix_Echo(t *testing.T) {
 }
 
 func Benchmark_Tcp_SpawnWorker_Stop(b *testing.B) {
-	ls, err := net.Listen("tcp", "localhost:9015")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if err == nil {
 		defer func() {
 			err := ls.Close()
@@ -459,7 +459,7 @@ func Benchmark_Tcp_SpawnWorker_Stop(b *testing.B) {
 }
 
 func Benchmark_Tcp_Worker_ExecEcho(b *testing.B) {
-	ls, err := net.Listen("tcp", "localhost:9016")
+	ls, err := net.Listen("tcp", "localhost:9007")
 	if err == nil {
 		defer func() {
 			err := ls.Close()

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -43,7 +43,7 @@ func Test_Tcp_Start(t *testing.T) {
 func Test_Tcp_StartCloseFactory(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9008")
 	if assert.NoError(t, err) {
 	} else {
 		t.Skip("socket is busy")
@@ -76,7 +76,7 @@ func Test_Tcp_StartCloseFactory(t *testing.T) {
 func Test_Tcp_StartError(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9009")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -102,7 +102,7 @@ func Test_Tcp_StartError(t *testing.T) {
 func Test_Tcp_Failboot(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9010")
 	if assert.NoError(t, err) {
 		defer func() {
 			err3 := ls.Close()
@@ -125,7 +125,7 @@ func Test_Tcp_Failboot(t *testing.T) {
 func Test_Tcp_Timeout(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9011")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -148,7 +148,7 @@ func Test_Tcp_Timeout(t *testing.T) {
 func Test_Tcp_Invalid(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9012")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -170,7 +170,7 @@ func Test_Tcp_Invalid(t *testing.T) {
 func Test_Tcp_Broken(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9013")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -207,7 +207,7 @@ func Test_Tcp_Broken(t *testing.T) {
 func Test_Tcp_Echo(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
 
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9014")
 	if assert.NoError(t, err) {
 		defer func() {
 			err := ls.Close()
@@ -428,7 +428,7 @@ func Test_Unix_Echo(t *testing.T) {
 }
 
 func Benchmark_Tcp_SpawnWorker_Stop(b *testing.B) {
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9015")
 	if err == nil {
 		defer func() {
 			err := ls.Close()
@@ -459,7 +459,7 @@ func Benchmark_Tcp_SpawnWorker_Stop(b *testing.B) {
 }
 
 func Benchmark_Tcp_Worker_ExecEcho(b *testing.B) {
-	ls, err := net.Listen("tcp", "localhost:9007")
+	ls, err := net.Listen("tcp", "localhost:9016")
 	if err == nil {
 		defer func() {
 			err := ls.Close()

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -193,14 +193,16 @@ func Test_Tcp_Broken(t *testing.T) {
 	}()
 
 	defer func() {
-		err = w.Stop()
-		assert.Error(t, err)
+		time.Sleep(time.Second)
+		err2 := w.Stop()
+		assert.NoError(t, err2)
 	}()
 
 	res, err := w.Exec(&Payload{Body: []byte("hello")})
 
 	assert.Error(t, err)
 	assert.Nil(t, res)
+	return
 }
 
 func Test_Tcp_Echo(t *testing.T) {

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -107,7 +107,7 @@ func Test_Tcp_Failboot(t *testing.T) {
 		defer func() {
 			err3 := ls.Close()
 			if err3 != nil {
-				t.Errorf("error closing the listener: error %v", err)
+				t.Errorf("error closing the listener: error %v", err3)
 			}
 		}()
 	} else {

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -105,8 +105,8 @@ func Test_Tcp_Failboot(t *testing.T) {
 	ls, err := net.Listen("tcp", "localhost:9007")
 	if assert.NoError(t, err) {
 		defer func() {
-			err := ls.Close()
-			if err != nil {
+			err3 := ls.Close()
+			if err3 != nil {
 				t.Errorf("error closing the listener: error %v", err)
 			}
 		}()
@@ -116,10 +116,10 @@ func Test_Tcp_Failboot(t *testing.T) {
 
 	cmd := exec.Command("php", "tests/failboot.php")
 
-	w, err := NewSocketFactory(ls, time.Minute).SpawnWorker(cmd)
+	w, err2 := NewSocketFactory(ls, time.Minute).SpawnWorker(cmd)
 	assert.Nil(t, w)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failboot")
+	assert.Error(t, err2)
+	assert.Contains(t, err2.Error(), "failboot")
 }
 
 func Test_Tcp_Timeout(t *testing.T) {

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -202,7 +202,6 @@ func Test_Tcp_Broken(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, res)
-	return
 }
 
 func Test_Tcp_Echo(t *testing.T) {

--- a/socket_factory_test.go
+++ b/socket_factory_test.go
@@ -377,8 +377,9 @@ func Test_Unix_Broken(t *testing.T) {
 	}()
 
 	defer func() {
+		time.Sleep(time.Second)
 		err = w.Stop()
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	}()
 
 	res, err := w.Exec(&Payload{Body: []byte("hello")})

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -151,11 +151,10 @@ func Test_StaticPool_Broken_Replace(t *testing.T) {
 		cfg,
 	)
 	assert.NoError(t, err)
-	defer p.Destroy()
-
 	assert.NotNil(t, p)
 
 	done := make(chan interface{})
+
 	p.Listen(func(e int, ctx interface{}) {
 		if err, ok := ctx.(error); ok {
 			if strings.Contains(err.Error(), "undefined_function()") {
@@ -170,7 +169,9 @@ func Test_StaticPool_Broken_Replace(t *testing.T) {
 	assert.Nil(t, res)
 
 	<-done
+	p.Destroy()
 }
+
 
 func Test_StaticPool_Broken_FromOutside(t *testing.T) {
 	p, err := NewPool(

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -233,7 +233,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 			assert.NoError(t, err)
 			close(done)
 		} else {
-			t.Fatal("Pool is nil")
+			panic("Pool is nil")
 		}
 	}()
 

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -238,7 +238,9 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 
 	_, err = p.Exec(&Payload{Body: []byte("10")})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "worker timeout")
+	if err != nil {
+		assert.Contains(t, err.Error(), "worker timeout")
+	}
 
 	<-done
 	p.Destroy()

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -234,7 +234,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	}()
 
 	// to ensure that worker is already busy
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 1)
 
 	_, err = p.Exec(&Payload{Body: []byte("10")})
 	assert.Error(t, err)

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -218,7 +218,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 		NewPipeFactory(),
 		Config{
 			NumWorkers:      1,
-			AllocateTimeout: time.Millisecond * 50,
+			AllocateTimeout: time.Nanosecond * 1,
 			DestroyTimeout:  time.Second * 2,
 		},
 	)

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -222,16 +222,21 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 			DestroyTimeout:  time.Second,
 		},
 	)
-
-	assert.NotNil(t, p)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	done := make(chan interface{})
 	go func() {
-		_, err := p.Exec(&Payload{Body: []byte("100")})
-		assert.NoError(t, err)
-		close(done)
+		if p != nil {
+			_, err := p.Exec(&Payload{Body: []byte("100")})
+			assert.NoError(t, err)
+			close(done)
+		} else {
+			t.Fatal("Pool is nil")
+		}
 	}()
+
 
 	// to ensure that worker is already busy
 	time.Sleep(time.Millisecond * 10)

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -228,6 +228,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	}
 
 	done := make(chan interface{})
+
 	go func() {
 		if p != nil {
 			_, err := p.Exec(&Payload{Body: []byte("100")})
@@ -236,17 +237,17 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 		} else {
 			panic("Pool is nil")
 		}
+
+		// to ensure that worker is already busy
+		time.Sleep(time.Millisecond * 100)
+
+		_, err = p.Exec(&Payload{Body: []byte("10")})
+		if err == nil {
+			t.Fatal("Test_StaticPool_AllocateTimeout exec should raise error")
+		}
+		assert.Contains(t, err.Error(), "worker timeout")
 	}()
 
-
-	// to ensure that worker is already busy
-	time.Sleep(time.Millisecond * 10)
-
-	_, err = p.Exec(&Payload{Body: []byte("10")})
-	if err == nil {
-		t.Fatal("Test_StaticPool_AllocateTimeout exec should raise error")
-	}
-	assert.Contains(t, err.Error(), "worker timeout")
 
 	<-done
 	p.Destroy()

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -219,7 +219,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 		NewPipeFactory(),
 		Config{
 			NumWorkers:      1,
-			AllocateTimeout: time.Millisecond * 50,
+			AllocateTimeout: time.Nanosecond * 1,
 			DestroyTimeout:  time.Second * 2,
 		},
 	)

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -219,7 +219,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 		Config{
 			NumWorkers:      1,
 			AllocateTimeout: time.Millisecond * 50,
-			DestroyTimeout:  time.Second,
+			DestroyTimeout:  time.Second * 2,
 		},
 	)
 	if err != nil {
@@ -242,10 +242,10 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 
 	_, err = p.Exec(&Payload{Body: []byte("10")})
-	assert.Error(t, err)
-	if err != nil {
-		assert.Contains(t, err.Error(), "worker timeout")
+	if err == nil {
+		t.Fatal("Test_StaticPool_AllocateTimeout exec should raise error")
 	}
+	assert.Contains(t, err.Error(), "worker timeout")
 
 	<-done
 	p.Destroy()

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -234,7 +234,7 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	}()
 
 	// to ensure that worker is already busy
-	time.Sleep(time.Millisecond * 1)
+	time.Sleep(time.Millisecond * 10)
 
 	_, err = p.Exec(&Payload{Body: []byte("10")})
 	assert.Error(t, err)

--- a/util/network.go
+++ b/util/network.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin freebsd
 
 package util
 

--- a/util/network_windows.go
+++ b/util/network_windows.go
@@ -1,11 +1,10 @@
-// +build linux
+// +build windows
 
 package util
 
 import (
 	"errors"
 	"fmt"
-	"github.com/valyala/tcplisten"
 	"net"
 	"os"
 	"strings"
@@ -30,27 +29,5 @@ func CreateListener(address string) (net.Listener, error) {
 		}
 	}
 
-	cfg := tcplisten.Config{
-		ReusePort:   true,
-		DeferAccept: true,
-		FastOpen:    true,
-		Backlog:     0,
-	}
-
-	// tcp4 is currently supported
-	if dsn[0] == "tcp" {
-		return cfg.NewListener("tcp4", dsn[1])
-	}
-
 	return net.Listen(dsn[0], dsn[1])
-}
-
-// fileExists checks if a file exists and is not a directory before we
-// try using it to prevent further errors.
-func fileExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
 }

--- a/util/network_windows_test.go
+++ b/util/network_windows_test.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build windows
 
 package util
 
@@ -13,10 +13,4 @@ func TestCreateListener(t *testing.T) {
 
 	_, err = CreateListener("aaa://192.168.0.1")
 	assert.Error(t, err, "Invalid Protocol (tcp://:6001, unix://file.sock)")
-}
-
-func TestUnixCreateListener(t *testing.T) {
-	l, err := CreateListener("unix://file.sock")
-	assert.NoError(t, err)
-	l.Close()
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -169,7 +169,7 @@ func Test_Broken(t *testing.T) {
 
 	defer func() {
 		err := w.Stop()
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	}()
 
 	res, err := w.Exec(&Payload{Body: []byte("hello")})

--- a/worker_test.go
+++ b/worker_test.go
@@ -171,7 +171,7 @@ func Test_Broken(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "undefined_function()")
 	}()
-	
+
 	res, err := w.Exec(&Payload{Body: []byte("hello")})
 	assert.Nil(t, res)
 	assert.NotNil(t, err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -161,22 +161,23 @@ func Test_Echo_Slow(t *testing.T) {
 func Test_Broken(t *testing.T) {
 	cmd := exec.Command("php", "tests/client.php", "broken", "pipes")
 
-	w, _ := NewPipeFactory().SpawnWorker(cmd)
+	w, err := NewPipeFactory().SpawnWorker(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
 		err := w.Wait()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "undefined_function()")
 	}()
-
-	defer func() {
-		time.Sleep(time.Second)
-		err := w.Stop()
-		assert.NoError(t, err)
-	}()
-
+	
 	res, err := w.Exec(&Payload{Body: []byte("hello")})
 	assert.Nil(t, res)
 	assert.NotNil(t, err)
+
+	time.Sleep(time.Second)
+	assert.NoError(t, w.Stop())
 }
 
 func Test_OnStarted(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os/exec"
 	"testing"
+	"time"
 )
 
 func Test_GetState(t *testing.T) {
@@ -168,6 +169,7 @@ func Test_Broken(t *testing.T) {
 	}()
 
 	defer func() {
+		time.Sleep(time.Second)
 		err := w.Stop()
 		assert.NoError(t, err)
 	}()


### PR DESCRIPTION
Fixes #220 

0. Add reuse, defer and fast-accept to tcp4 net.Listener
1. Add new target - macOS-latest for tests
2. Add new golang version go 1.14, remove go 1.12
3. Update various tests (timeouts, defers, goroutines order)
4. Add new tests for File Watcher (directory copy)