### PR TITLE
Update Dockerfile labels in favor of OCI spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,12 @@ RUN set -x \
 FROM alpine:latest
 
 LABEL \
-    org.label-schema.name="roadrunner" \
-    org.label-schema.description="High-performance PHP application server, load-balancer and process manager" \
-    org.label-schema.url="https://github.com/spiral/roadrunner" \
-    org.label-schema.vcs-url="https://github.com/spiral/roadrunner" \
-    org.label-schema.vendor="SpiralScout" \
-    org.label-schema.license="MIT" \
-    org.label-schema.schema-version="1.0"
+    org.opencontainers.image.title="roadrunner" \
+    org.opencontainers.image.description="High-performance PHP application server, load-balancer and process manager" \
+    org.opencontainers.image.url="https://github.com/spiral/roadrunner" \
+    org.opencontainers.image.source="https://github.com/spiral/roadrunner" \
+    org.opencontainers.image.vendor="SpiralScout" \
+    org.opencontainers.image.licenses="MIT"
 
 COPY --from=builder /src/rr /usr/bin/rr
 COPY --from=builder /src/.rr.yaml /etc/rr.yaml


### PR DESCRIPTION
👋 I just want to propose this update, so I'm creating this as a draft PR so that it's even easier to +1 or -1.

Since the Label Schema convention [has become deprecated in favor of the Open Containers Initiative spec](http://label-schema.org/rc1/#background), this updates all of the previous Label Schema keys to [the OCI equivalent](https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema).

If you're concerned with removing the current labels and would to transition to the OCI spec after some time, I can update this to simply add the OCI labels as well. There is no harm in having both.