### PR TITLE
Fix HSTS header

### DIFF
--- a/service/http/service.go
+++ b/service/http/service.go
@@ -6,6 +6,13 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/fcgi"
+	"net/url"
+	"strings"
+	"sync"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spiral/roadrunner"
 	"github.com/spiral/roadrunner/service/env"
@@ -14,12 +21,6 @@ import (
 	"github.com/spiral/roadrunner/util"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"io/ioutil"
-	"net/http"
-	"net/http/fcgi"
-	"net/url"
-	"strings"
-	"sync"
 )
 
 const (
@@ -264,7 +265,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.https != nil && r.TLS != nil {
-		w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		w.Header().Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 	}
 
 	r = attributes.Init(r)


### PR DESCRIPTION
Fix HSTS header publish by default and can't overwrite from PHP.

— Serve an HSTS header on the base domain for HTTPS requests:
—— The `max-age` must be at least _31536000_ seconds (1 year).
—— The `includeSubDomains` directive must be specified.
—— The `preload` directive must be specified.

Reference: https://hstspreload.org