### PR TITLE
Add new pool event: EventNoFreeWorkers 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/spf13/viper v1.7.1
 	github.com/spiral/endure v1.0.0-beta20
-	github.com/spiral/errors v1.0.4
+	github.com/spiral/errors v1.0.5
 	github.com/spiral/goridge/v2 v2.4.6
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/spiral/endure v1.0.0-beta20 h1:QD3EJ6CRLgeo/6trfnlUcQhH3vrK8Hvf9ceDpd
 github.com/spiral/endure v1.0.0-beta20/go.mod h1:qCU2/4gAItVESzUK0yPExmUTlTcpRLqJUgcV+nqxn+o=
 github.com/spiral/errors v1.0.4 h1:Y6Bop9GszdDh+Dn3s5aqsGebNLydqZ1F6OdOIQ9EpU0=
 github.com/spiral/errors v1.0.4/go.mod h1:SwMSZVdZkkJVgXNNafccqOaxWg0XPzVU/dEdUEInE0o=
+github.com/spiral/errors v1.0.5 h1:TwlR9cZtTgnZrSngcEUpyiMO9yJ45gdQ+XcrCRoCCAM=
+github.com/spiral/errors v1.0.5/go.mod h1:SwMSZVdZkkJVgXNNafccqOaxWg0XPzVU/dEdUEInE0o=
 github.com/spiral/goridge/v2 v2.4.6 h1:9u/mrxCtOSy0lnumrpPCSOlGBX/Vprid/hFsnzWrd6k=
 github.com/spiral/goridge/v2 v2.4.6/go.mod h1:mYjL+Ny7nVfLqjRwIYV2pUSQ61eazvVclHII6FfZfYc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/plugins/http/tests/http_test.go
+++ b/plugins/http/tests/http_test.go
@@ -811,7 +811,7 @@ func TestHttpMiddleware(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
-		tt := time.NewTimer(time.Second * 10)
+		tt := time.NewTimer(time.Second * 15)
 		defer wg.Done()
 		for {
 			select {

--- a/pool.go
+++ b/pool.go
@@ -30,6 +30,9 @@ const (
 	// EventSupervisorError triggered when supervisor can not complete work.
 	EventSupervisorError
 
+	// EventNoFreeWorkers triggered when there are no free workers in the stack and timeout for worker allocate elapsed
+	EventNoFreeWorkers
+
 	// todo: EventMaxMemory caused when worker consumes more memory than allowed.
 	EventMaxMemory
 
@@ -60,7 +63,7 @@ type Pool interface {
 	Workers() (workers []WorkerBase)
 
 	// Remove worker from the pool.
-	RemoveWorker(ctx context.Context, worker WorkerBase) error
+	RemoveWorker(worker WorkerBase) error
 
 	// Destroy all underlying stack (but let them to complete the task).
 	Destroy(ctx context.Context)

--- a/static_pool_test.go
+++ b/static_pool_test.go
@@ -153,7 +153,7 @@ func Test_StaticPool_JobError(t *testing.T) {
 	assert.Nil(t, res.Body)
 	assert.Nil(t, res.Context)
 
-	if errors.Is(errors.Exec, err) == false {
+	if errors.Is(errors.ErrSoftJob, err) == false {
 		t.Fatal("error should be of type errors.Exec")
 	}
 
@@ -273,6 +273,9 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 		},
 	)
 	assert.Error(t, err)
+	if !errors.Is(errors.WorkerAllocate, err) {
+		t.Fatal("error should be of type WorkerAllocate")
+	}
 	assert.Nil(t, p)
 }
 

--- a/sync_worker_test.go
+++ b/sync_worker_test.go
@@ -70,7 +70,7 @@ func Test_BadPayload(t *testing.T) {
 	assert.Nil(t, res.Body)
 	assert.Nil(t, res.Context)
 
-	assert.Equal(t, "payload can not be empty", err.Error())
+	assert.Contains(t, err.Error(), "payload can not be empty")
 }
 
 func Test_NotStarted_String(t *testing.T) {
@@ -98,7 +98,7 @@ func Test_NotStarted_Exec(t *testing.T) {
 	assert.Nil(t, res.Body)
 	assert.Nil(t, res.Context)
 
-	assert.Equal(t, "WorkerProcess is not ready (inactive)", err.Error())
+	assert.Contains(t, err.Error(), "WorkerProcess is not ready (inactive)")
 }
 
 func Test_String(t *testing.T) {
@@ -215,10 +215,10 @@ func Test_Error(t *testing.T) {
 	assert.Nil(t, res.Body)
 	assert.Nil(t, res.Context)
 
-	if errors.Is(errors.Exec, err) == false {
-		t.Fatal("error should be of type errors.Exec")
+	if errors.Is(errors.ErrSoftJob, err) == false {
+		t.Fatal("error should be of type errors.ErrSoftJob")
 	}
-	assert.Contains(t, err.Error(), "exec payload: Exec: hello")
+	assert.Contains(t, err.Error(), "exec payload: SoftJobError: hello")
 }
 
 func Test_NumExecs(t *testing.T) {


### PR DESCRIPTION
This event indicates that RR can't get workers from the stack during the allowed allocated timeout.
resolves #401 