### PR TITLE
[RR2] Bugfix/missed pool events

### DIFF
--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -63,7 +63,7 @@ func (z *ZapLogger) ServiceLogger(n endure.Named) (Logger, error) {
 // Provides declares factory methods.
 func (z *ZapLogger) Provides() []interface{} {
 	return []interface{}{
+		//z.DefaultLogger,
 		z.ServiceLogger,
-		z.DefaultLogger,
 	}
 }

--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -63,7 +63,7 @@ func (z *ZapLogger) ServiceLogger(n endure.Named) (Logger, error) {
 // Provides declares factory methods.
 func (z *ZapLogger) Provides() []interface{} {
 	return []interface{}{
-		z.DefaultLogger,
 		z.ServiceLogger,
+		z.DefaultLogger,
 	}
 }

--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -63,7 +63,7 @@ func (z *ZapLogger) ServiceLogger(n endure.Named) (Logger, error) {
 // Provides declares factory methods.
 func (z *ZapLogger) Provides() []interface{} {
 	return []interface{}{
-		//z.DefaultLogger,
+		z.DefaultLogger,
 		z.ServiceLogger,
 	}
 }

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -131,8 +131,11 @@ func (server *Plugin) NewWorkerPool(ctx context.Context, opt poolImpl.Config, en
 		return nil, errors.E(op, err)
 	}
 
-	list := make([]events.Listener, 0, len(listeners)+1)
-	list = append(listeners, server.collectPoolLogs)
+	list := make([]events.Listener, 0, 1)
+	list = append(list, server.collectPoolLogs)
+	if len(listeners) != 0 {
+		list = append(list, listeners...)
+	}
 
 	p, err := poolImpl.Initialize(ctx, spawnCmd, server.factory, opt, poolImpl.AddListeners(list...))
 	if err != nil {

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -131,8 +131,8 @@ func (server *Plugin) NewWorkerPool(ctx context.Context, opt poolImpl.Config, en
 		return nil, errors.E(op, err)
 	}
 
-	list := make([]events.Listener, 0, len(listeners))
-	list = append(list, server.collectPoolLogs)
+	list := make([]events.Listener, 0, len(listeners)+1)
+	list = append(listeners, server.collectPoolLogs)
 
 	p, err := poolImpl.Initialize(ctx, spawnCmd, server.factory, opt, poolImpl.AddListeners(list...))
 	if err != nil {


### PR DESCRIPTION
This PR fixes incorrect usage of the `server.NewWorkerPool` listeners function parameter.
`listeners` were not passed to the underline worker's pool.