### PR TITLE
fix(yaml): Use mapstructure structure tags instead of yaml

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -13,23 +13,23 @@ server:
 
 logs:
   mode: development
-  level: error
+  level: debug
 
 http:
   address: 127.0.0.1:44933
   max_request_size: 1024
-  middleware: ["gzip", "headers"]
+  middleware: [ "gzip", "headers" ]
   uploads:
-    forbid: [".php", ".exe", ".bat"]
+    forbid: [ ".php", ".exe", ".bat" ]
   trusted_subnets:
     [
-      "10.0.0.0/8",
-      "127.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16",
-      "::1/128",
-      "fc00::/7",
-      "fe80::/10",
+        "10.0.0.0/8",
+        "127.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
     ]
   pool:
     num_workers: 6
@@ -38,21 +38,21 @@ http:
     destroy_timeout: 60s
     supervisor:
       # WatchTick defines how often to check the state of worker (seconds)
-      watch_tick: 10
+      watch_tick: 1
       # TTL defines maximum time worker is allowed to live (seconds)
-      ttl: 10
+      ttl: 0
       # IdleTTL defines maximum duration worker can spend in idle mode. Disabled when 0 (seconds)
-      idle_ttl: 10
+      idle_ttl: 100
       # ExecTTL defines maximum lifetime per job (seconds)
       exec_ttl: 10
       # MaxWorkerMemory limits memory per worker (MB)
       max_worker_memory: 100
 
-  ssl:
-    port: 8892
-    redirect: false
-    cert: fixtures/server.crt
-    key: fixtures/server.key
+  #  ssl:
+  #    port: 8892
+  #    redirect: false
+  #    cert: fixtures/server.crt
+  #    key: fixtures/server.key
   #    rootCa: root.crt
   fcgi:
     address: tcp://0.0.0.0:7921
@@ -68,7 +68,7 @@ redis:
   # cluster-specific applications locally.
   # if the number of addrs is 1 and master_name is empty, a single-node redis Client will be returned
 
-  # if the number of Addrs is two or more, a ClusterClient will be returned
+  # if the number of addrs is two or more, a ClusterClient will be returned
   addrs:
     - "localhost:6379"
   # if a MasterName is passed a sentinel-backed FailoverClient will be returned
@@ -120,8 +120,8 @@ metrics:
     app_metric:
       type: histogram
       help: "Custom application metric"
-      labels: ["type"]
-      buckets: [0.1, 0.2, 0.3, 1.0]
+      labels: [ "type" ]
+      buckets: [ 0.1, 0.2, 0.3, 1.0 ]
       # objectives defines the quantile rank estimates with their respective
       #	absolute error [ for summary only ]
       objectives:
@@ -132,16 +132,16 @@ reload:
   # sync interval
   interval: 1s
   # global patterns to sync
-  patterns: [".go"]
+  patterns: [ ".go" ]
   # list of included for sync services
   services:
     http:
       # recursive search for file patterns to add
       recursive: true
       # ignored folders
-      ignore: ["vendor"]
+      ignore: [ "vendor" ]
       # service specific file pattens to sync
-      patterns: [".php", ".go", ".md"]
+      patterns: [ ".php", ".go", ".md" ]
       # directories to sync. If recursive is set to true,
       # recursive sync will be applied only to the directories in `dirs` section
-      dirs: ["."]
+      dirs: [ "." ]

--- a/pkg/pool/config.go
+++ b/pkg/pool/config.go
@@ -12,23 +12,23 @@ type Config struct {
 
 	// NumWorkers defines how many sub-processes can be run at once. This value
 	// might be doubled by Swapper while hot-swap. Defaults to number of CPU cores.
-	NumWorkers int64 `yaml:"num_workers"`
+	NumWorkers int64 `mapstructure:"num_workers"`
 
 	// MaxJobs defines how many executions is allowed for the worker until
 	// it's destruction. set 1 to create new process for each new task, 0 to let
 	// worker handle as many tasks as it can.
-	MaxJobs int64 `yaml:"max_jobs"`
+	MaxJobs int64 `mapstructure:"max_jobs"`
 
 	// AllocateTimeout defines for how long pool will be waiting for a worker to
 	// be freed to handle the task. Defaults to 60s.
-	AllocateTimeout time.Duration `yaml:"allocate_timeout"`
+	AllocateTimeout time.Duration `mapstructure:"allocate_timeout"`
 
 	// DestroyTimeout defines for how long pool should be waiting for worker to
 	// properly destroy, if timeout reached worker will be killed. Defaults to 60s.
-	DestroyTimeout time.Duration `yaml:"destroy_timeout"`
+	DestroyTimeout time.Duration `mapstructure:"destroy_timeout"`
 
 	// Supervision config to limit worker and pool memory usage.
-	Supervisor *SupervisorConfig `yaml:"supervisor"`
+	Supervisor *SupervisorConfig `mapstructure:"supervisor"`
 }
 
 // InitDefaults enables default config values.
@@ -52,19 +52,19 @@ func (cfg *Config) InitDefaults() {
 
 type SupervisorConfig struct {
 	// WatchTick defines how often to check the state of worker.
-	WatchTick uint64 `yaml:"watch_tick"`
+	WatchTick uint64 `mapstructure:"watch_tick"`
 
 	// TTL defines maximum time worker is allowed to live.
-	TTL uint64 `yaml:"ttl"`
+	TTL uint64 `mapstructure:"ttl"`
 
 	// IdleTTL defines maximum duration worker can spend in idle mode. Disabled when 0.
-	IdleTTL uint64 `yaml:"idle_ttl"`
+	IdleTTL uint64 `mapstructure:"idle_ttl"`
 
 	// ExecTTL defines maximum lifetime per job.
-	ExecTTL uint64 `yaml:"exec_ttl"`
+	ExecTTL uint64 `mapstructure:"exec_ttl"`
 
 	// MaxWorkerMemory limits memory per worker.
-	MaxWorkerMemory uint64 `yaml:"max_worker_memory"`
+	MaxWorkerMemory uint64 `mapstructure:"max_worker_memory"`
 }
 
 // InitDefaults enables default config values.

--- a/pkg/pool/static_pool.go
+++ b/pkg/pool/static_pool.go
@@ -54,7 +54,7 @@ type StaticPool struct {
 
 // Initialize creates new worker pool and task multiplexer. StaticPool will initiate with one worker.
 func Initialize(ctx context.Context, cmd Command, factory worker.Factory, cfg Config, options ...Options) (pool.Pool, error) {
-	const op = errors.Op("Initialize")
+	const op = errors.Op("static pool initialize")
 	if factory == nil {
 		return nil, errors.E(op, errors.Str("no factory initialized"))
 	}

--- a/plugins/http/config.go
+++ b/plugins/http/config.go
@@ -49,16 +49,16 @@ type Config struct {
 	HTTP2 *HTTP2Config
 
 	// MaxRequestSize specified max size for payload body in megabytes, set 0 to unlimited.
-	MaxRequestSize uint64 `yaml:"max_request_size"`
+	MaxRequestSize uint64 `mapstructure:"max_request_size"`
 
 	// TrustedSubnets declare IP subnets which are allowed to set ip using X-Real-Ip and X-Forwarded-For
-	TrustedSubnets []string `yaml:"trusted_subnets"`
+	TrustedSubnets []string `mapstructure:"trusted_subnets"`
 
 	// Uploads configures uploads configuration.
 	Uploads *UploadsConfig
 
 	// Pool configures worker pool.
-	Pool *poolImpl.Config
+	Pool *poolImpl.Config `mapstructure:"pool"`
 
 	// Env is environment variables passed to the  http pool
 	Env map[string]string
@@ -85,7 +85,7 @@ type HTTP2Config struct {
 	H2C bool
 
 	// MaxConcurrentStreams defaults to 128.
-	MaxConcurrentStreams uint32 `yaml:"max_concurrent_streams"`
+	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams"`
 }
 
 // InitDefaults sets default values for HTTP/2 configuration.

--- a/plugins/http/handler.go
+++ b/plugins/http/handler.go
@@ -24,7 +24,7 @@ const (
 )
 
 // MB is 1024 bytes
-const MB = 1024 * 1024
+const MB uint64 = 1024 * 1024
 
 // ErrorEvent represents singular http error event.
 type ErrorEvent struct {

--- a/plugins/kv/boltdb/config.go
+++ b/plugins/kv/boltdb/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	// db file permissions
 	Permissions int
 	// timeout
-	Interval uint `yaml:"interval"`
+	Interval uint `mapstructure:"interval"`
 }
 
 // InitDefaults initializes default values for the boltdb

--- a/plugins/logger/config.go
+++ b/plugins/logger/config.go
@@ -10,26 +10,26 @@ import (
 // ChannelConfig configures loggers per channel.
 type ChannelConfig struct {
 	// Dedicated channels per logger. By default logger allocated via named logger.
-	Channels map[string]Config `json:"channels" yaml:"channels"`
+	Channels map[string]Config `json:"channels" mapstructure:"channels"`
 }
 
 type Config struct {
 	// Mode configures logger based on some default template (development, production, off).
-	Mode string `json:"mode" yaml:"mode"`
+	Mode string `json:"mode" mapstructure:"mode"`
 
 	// Level is the minimum enabled logging level. Note that this is a dynamic
 	// level, so calling ChannelConfig.Level.SetLevel will atomically change the log
 	// level of all loggers descended from this config.
-	Level string `json:"level" yaml:"level"`
+	Level string `json:"level" mapstructure:"level"`
 
 	// Encoding sets the logger's encoding. Valid values are "json" and
 	// "console", as well as any third-party encodings registered via
 	// RegisterEncoder.
-	Encoding string `json:"encoding" yaml:"encoding"`
+	Encoding string `json:"encoding" mapstructure:"encoding"`
 
 	// Output is a list of URLs or file paths to write logging output to.
 	// See Open for details.
-	Output []string `json:"output" yaml:"output"`
+	Output []string `json:"output" mapstructure:"output"`
 
 	// ErrorOutput is a list of URLs to write internal logger errors to.
 	// The default is standard error.
@@ -37,7 +37,7 @@ type Config struct {
 	// Note that this setting only affects internal errors; for sample code that
 	// sends error-level logs to a different location from info- and debug-level
 	// logs, see the package-level AdvancedConfiguration example.
-	ErrorOutput []string `json:"errorOutput" yaml:"errorOutput"`
+	ErrorOutput []string `json:"errorOutput" mapstructure:"errorOutput"`
 }
 
 // ZapConfig converts config into Zap configuration.

--- a/plugins/redis/config.go
+++ b/plugins/redis/config.go
@@ -3,27 +3,27 @@ package redis
 import "time"
 
 type Config struct {
-	Addrs            []string      `yaml:"addrs"`
-	DB               int           `yaml:"db"`
-	Username         string        `yaml:"username"`
-	Password         string        `yaml:"password"`
-	MasterName       string        `yaml:"master_name"`
-	SentinelPassword string        `yaml:"sentinel_password"`
-	RouteByLatency   bool          `yaml:"route_by_latency"`
-	RouteRandomly    bool          `yaml:"route_randomly"`
-	MaxRetries       int           `yaml:"max_retries"`
-	DialTimeout      time.Duration `yaml:"dial_timeout"`
-	MinRetryBackoff  time.Duration `yaml:"min_retry_backoff"`
-	MaxRetryBackoff  time.Duration `yaml:"max_retry_backoff"`
-	PoolSize         int           `yaml:"pool_size"`
-	MinIdleConns     int           `yaml:"min_idle_conns"`
-	MaxConnAge       time.Duration `yaml:"max_conn_age"`
-	ReadTimeout      time.Duration `yaml:"read_timeout"`
-	WriteTimeout     time.Duration `yaml:"write_timeout"`
-	PoolTimeout      time.Duration `yaml:"pool_timeout"`
-	IdleTimeout      time.Duration `yaml:"idle_timeout"`
-	IdleCheckFreq    time.Duration `yaml:"idle_check_freq"`
-	ReadOnly         bool          `yaml:"read_only"`
+	Addrs            []string      `mapstructure:"addrs"`
+	DB               int           `mapstructure:"db"`
+	Username         string        `mapstructure:"username"`
+	Password         string        `mapstructure:"password"`
+	MasterName       string        `mapstructure:"master_name"`
+	SentinelPassword string        `mapstructure:"sentinel_password"`
+	RouteByLatency   bool          `mapstructure:"route_by_latency"`
+	RouteRandomly    bool          `mapstructure:"route_randomly"`
+	MaxRetries       int           `mapstructure:"max_retries"`
+	DialTimeout      time.Duration `mapstructure:"dial_timeout"`
+	MinRetryBackoff  time.Duration `mapstructure:"min_retry_backoff"`
+	MaxRetryBackoff  time.Duration `mapstructure:"max_retry_backoff"`
+	PoolSize         int           `mapstructure:"pool_size"`
+	MinIdleConns     int           `mapstructure:"min_idle_conns"`
+	MaxConnAge       time.Duration `mapstructure:"max_conn_age"`
+	ReadTimeout      time.Duration `mapstructure:"read_timeout"`
+	WriteTimeout     time.Duration `mapstructure:"write_timeout"`
+	PoolTimeout      time.Duration `mapstructure:"pool_timeout"`
+	IdleTimeout      time.Duration `mapstructure:"idle_timeout"`
+	IdleCheckFreq    time.Duration `mapstructure:"idle_check_freq"`
+	ReadOnly         bool          `mapstructure:"read_only"`
 }
 
 // InitDefaults initializing fill config with default values

--- a/plugins/server/config.go
+++ b/plugins/server/config.go
@@ -10,129 +10,129 @@ type Config struct {
 	// Server config section
 	Server struct {
 		// Command to run as application.
-		Command string `yaml:"command"`
+		Command string `mapstructure:"command"`
 		// User to run application under.
-		User string `yaml:"user"`
+		User string `mapstructure:"user"`
 		// Group to run application under.
-		Group string `yaml:"group"`
+		Group string `mapstructure:"group"`
 		// Env represents application environment.
-		Env Env `yaml:"env"`
+		Env Env `mapstructure:"env"`
 		// Relay defines connection method and factory to be used to connect to workers:
 		// "pipes", "tcp://:6001", "unix://rr.sock"
 		// This config section must not change on re-configuration.
-		Relay string `yaml:"relay"`
+		Relay string `mapstructure:"relay"`
 		// RelayTimeout defines for how long socket factory will be waiting for worker connection. This config section
 		// must not change on re-configuration. Defaults to 60s.
-		RelayTimeout time.Duration `yaml:"relayTimeout"`
-	} `yaml:"server"`
+		RelayTimeout time.Duration `mapstructure:"relayTimeout"`
+	} `mapstructure:"server"`
 
 	RPC *struct {
-		Listen string `yaml:"listen"`
-	} `yaml:"rpc"`
+		Listen string `mapstructure:"listen"`
+	} `mapstructure:"rpc"`
 	Logs *struct {
-		Mode  string `yaml:"mode"`
-		Level string `yaml:"level"`
-	} `yaml:"logs"`
+		Mode  string `mapstructure:"mode"`
+		Level string `mapstructure:"level"`
+	} `mapstructure:"logs"`
 	HTTP *struct {
-		Address        string   `yaml:"address"`
-		MaxRequestSize int      `yaml:"max_request_size"`
-		Middleware     []string `yaml:"middleware"`
+		Address        string   `mapstructure:"address"`
+		MaxRequestSize int      `mapstructure:"max_request_size"`
+		Middleware     []string `mapstructure:"middleware"`
 		Uploads        struct {
-			Forbid []string `yaml:"forbid"`
-		} `yaml:"uploads"`
-		TrustedSubnets []string `yaml:"trusted_subnets"`
+			Forbid []string `mapstructure:"forbid"`
+		} `mapstructure:"uploads"`
+		TrustedSubnets []string `mapstructure:"trusted_subnets"`
 		Pool           struct {
-			NumWorkers      int    `yaml:"num_workers"`
-			MaxJobs         int    `yaml:"max_jobs"`
-			AllocateTimeout string `yaml:"allocate_timeout"`
-			DestroyTimeout  string `yaml:"destroy_timeout"`
+			NumWorkers      int    `mapstructure:"num_workers"`
+			MaxJobs         int    `mapstructure:"max_jobs"`
+			AllocateTimeout string `mapstructure:"allocate_timeout"`
+			DestroyTimeout  string `mapstructure:"destroy_timeout"`
 			Supervisor      struct {
-				WatchTick       int `yaml:"watch_tick"`
-				TTL             int `yaml:"ttl"`
-				IdleTTL         int `yaml:"idle_ttl"`
-				ExecTTL         int `yaml:"exec_ttl"`
-				MaxWorkerMemory int `yaml:"max_worker_memory"`
-			} `yaml:"supervisor"`
-		} `yaml:"pool"`
+				WatchTick       int `mapstructure:"watch_tick"`
+				TTL             int `mapstructure:"ttl"`
+				IdleTTL         int `mapstructure:"idle_ttl"`
+				ExecTTL         int `mapstructure:"exec_ttl"`
+				MaxWorkerMemory int `mapstructure:"max_worker_memory"`
+			} `mapstructure:"supervisor"`
+		} `mapstructure:"pool"`
 		Ssl struct {
-			Port     int    `yaml:"port"`
-			Redirect bool   `yaml:"redirect"`
-			Cert     string `yaml:"cert"`
-			Key      string `yaml:"key"`
-		} `yaml:"ssl"`
+			Port     int    `mapstructure:"port"`
+			Redirect bool   `mapstructure:"redirect"`
+			Cert     string `mapstructure:"cert"`
+			Key      string `mapstructure:"key"`
+		} `mapstructure:"ssl"`
 		Fcgi struct {
-			Address string `yaml:"address"`
-		} `yaml:"fcgi"`
+			Address string `mapstructure:"address"`
+		} `mapstructure:"fcgi"`
 		HTTP2 struct {
-			Enabled              bool `yaml:"enabled"`
-			H2C                  bool `yaml:"h2c"`
-			MaxConcurrentStreams int  `yaml:"max_concurrent_streams"`
-		} `yaml:"http2"`
-	} `yaml:"http"`
+			Enabled              bool `mapstructure:"enabled"`
+			H2C                  bool `mapstructure:"h2c"`
+			MaxConcurrentStreams int  `mapstructure:"max_concurrent_streams"`
+		} `mapstructure:"http2"`
+	} `mapstructure:"http"`
 	Redis *struct {
-		Addrs            []string `yaml:"addrs"`
-		MasterName       string   `yaml:"master_name"`
-		Username         string   `yaml:"username"`
-		Password         string   `yaml:"password"`
-		DB               int      `yaml:"db"`
-		SentinelPassword string   `yaml:"sentinel_password"`
-		RouteByLatency   bool     `yaml:"route_by_latency"`
-		RouteRandomly    bool     `yaml:"route_randomly"`
-		DialTimeout      int      `yaml:"dial_timeout"`
-		MaxRetries       int      `yaml:"max_retries"`
-		MinRetryBackoff  int      `yaml:"min_retry_backoff"`
-		MaxRetryBackoff  int      `yaml:"max_retry_backoff"`
-		PoolSize         int      `yaml:"pool_size"`
-		MinIdleConns     int      `yaml:"min_idle_conns"`
-		MaxConnAge       int      `yaml:"max_conn_age"`
-		ReadTimeout      int      `yaml:"read_timeout"`
-		WriteTimeout     int      `yaml:"write_timeout"`
-		PoolTimeout      int      `yaml:"pool_timeout"`
-		IdleTimeout      int      `yaml:"idle_timeout"`
-		IdleCheckFreq    int      `yaml:"idle_check_freq"`
-		ReadOnly         bool     `yaml:"read_only"`
-	} `yaml:"redis"`
+		Addrs            []string `mapstructure:"addrs"`
+		MasterName       string   `mapstructure:"master_name"`
+		Username         string   `mapstructure:"username"`
+		Password         string   `mapstructure:"password"`
+		DB               int      `mapstructure:"db"`
+		SentinelPassword string   `mapstructure:"sentinel_password"`
+		RouteByLatency   bool     `mapstructure:"route_by_latency"`
+		RouteRandomly    bool     `mapstructure:"route_randomly"`
+		DialTimeout      int      `mapstructure:"dial_timeout"`
+		MaxRetries       int      `mapstructure:"max_retries"`
+		MinRetryBackoff  int      `mapstructure:"min_retry_backoff"`
+		MaxRetryBackoff  int      `mapstructure:"max_retry_backoff"`
+		PoolSize         int      `mapstructure:"pool_size"`
+		MinIdleConns     int      `mapstructure:"min_idle_conns"`
+		MaxConnAge       int      `mapstructure:"max_conn_age"`
+		ReadTimeout      int      `mapstructure:"read_timeout"`
+		WriteTimeout     int      `mapstructure:"write_timeout"`
+		PoolTimeout      int      `mapstructure:"pool_timeout"`
+		IdleTimeout      int      `mapstructure:"idle_timeout"`
+		IdleCheckFreq    int      `mapstructure:"idle_check_freq"`
+		ReadOnly         bool     `mapstructure:"read_only"`
+	} `mapstructure:"redis"`
 	Boltdb *struct {
-		Dir         string `yaml:"dir"`
-		File        string `yaml:"file"`
-		Bucket      string `yaml:"bucket"`
-		Permissions int    `yaml:"permissions"`
-		TTL         int    `yaml:"TTL"`
-	} `yaml:"boltdb"`
+		Dir         string `mapstructure:"dir"`
+		File        string `mapstructure:"file"`
+		Bucket      string `mapstructure:"bucket"`
+		Permissions int    `mapstructure:"permissions"`
+		TTL         int    `mapstructure:"TTL"`
+	} `mapstructure:"boltdb"`
 	Memcached *struct {
-		Addr []string `yaml:"addr"`
-	} `yaml:"memcached"`
+		Addr []string `mapstructure:"addr"`
+	} `mapstructure:"memcached"`
 	Memory *struct {
-		Enabled  bool `yaml:"enabled"`
-		Interval int  `yaml:"interval"`
-	} `yaml:"memory"`
+		Enabled  bool `mapstructure:"enabled"`
+		Interval int  `mapstructure:"interval"`
+	} `mapstructure:"memory"`
 	Metrics *struct {
-		Address string `yaml:"address"`
+		Address string `mapstructure:"address"`
 		Collect struct {
 			AppMetric struct {
-				Type       string    `yaml:"type"`
-				Help       string    `yaml:"help"`
-				Labels     []string  `yaml:"labels"`
-				Buckets    []float64 `yaml:"buckets"`
+				Type       string    `mapstructure:"type"`
+				Help       string    `mapstructure:"help"`
+				Labels     []string  `mapstructure:"labels"`
+				Buckets    []float64 `mapstructure:"buckets"`
 				Objectives []struct {
-					Num2 float64 `yaml:"2,omitempty"`
-					One4 float64 `yaml:"1.4,omitempty"`
-				} `yaml:"objectives"`
-			} `yaml:"app_metric"`
-		} `yaml:"collect"`
-	} `yaml:"metrics"`
+					Num2 float64 `mapstructure:"2,omitempty"`
+					One4 float64 `mapstructure:"1.4,omitempty"`
+				} `mapstructure:"objectives"`
+			} `mapstructure:"app_metric"`
+		} `mapstructure:"collect"`
+	} `mapstructure:"metrics"`
 	Reload *struct {
-		Interval string   `yaml:"interval"`
-		Patterns []string `yaml:"patterns"`
+		Interval string   `mapstructure:"interval"`
+		Patterns []string `mapstructure:"patterns"`
 		Services struct {
 			HTTP struct {
-				Recursive bool     `yaml:"recursive"`
-				Ignore    []string `yaml:"ignore"`
-				Patterns  []string `yaml:"patterns"`
-				Dirs      []string `yaml:"dirs"`
-			} `yaml:"http"`
-		} `yaml:"services"`
-	} `yaml:"reload"`
+				Recursive bool     `mapstructure:"recursive"`
+				Ignore    []string `mapstructure:"ignore"`
+				Patterns  []string `mapstructure:"patterns"`
+				Dirs      []string `mapstructure:"dirs"`
+			} `mapstructure:"http"`
+		} `mapstructure:"services"`
+	} `mapstructure:"reload"`
 }
 
 // InitDefaults for the server config

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -40,7 +40,7 @@ type Plugin struct {
 
 // Init application provider.
 func (server *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
-	const op = errors.Op("Init")
+	const op = errors.Op("server plugin init")
 	err := cfg.Unmarshal(&server.cfg)
 	if err != nil {
 		return errors.E(op, errors.Init, err)

--- a/tests/plugins/config/plugin1.go
+++ b/tests/plugins/config/plugin1.go
@@ -9,31 +9,31 @@ import (
 
 type AllConfig struct {
 	RPC struct {
-		Listen string `yaml:"listen"`
-	} `yaml:"rpc"`
+		Listen string `mapstructure:"listen"`
+	} `mapstructure:"rpc"`
 	Reload struct {
-		Enabled  bool     `yaml:"enabled"`
-		Interval string   `yaml:"interval"`
-		Patterns []string `yaml:"patterns"`
+		Enabled  bool     `mapstructure:"enabled"`
+		Interval string   `mapstructure:"interval"`
+		Patterns []string `mapstructure:"patterns"`
 		Services struct {
 			HTTP struct {
-				Recursive bool     `yaml:"recursive"`
-				Ignore    []string `yaml:"ignore"`
-				Patterns  []string `yaml:"patterns"`
-				Dirs      []string `yaml:"dirs"`
-			} `yaml:"http"`
+				Recursive bool     `mapstructure:"recursive"`
+				Ignore    []string `mapstructure:"ignore"`
+				Patterns  []string `mapstructure:"patterns"`
+				Dirs      []string `mapstructure:"dirs"`
+			} `mapstructure:"http"`
 			Jobs struct {
-				Recursive bool     `yaml:"recursive"`
-				Ignore    []string `yaml:"ignore"`
-				Dirs      []string `yaml:"dirs"`
-			} `yaml:"jobs"`
+				Recursive bool     `mapstructure:"recursive"`
+				Ignore    []string `mapstructure:"ignore"`
+				Dirs      []string `mapstructure:"dirs"`
+			} `mapstructure:"jobs"`
 			RPC struct {
-				Recursive bool     `yaml:"recursive"`
-				Patterns  []string `yaml:"patterns"`
-				Dirs      []string `yaml:"dirs"`
-			} `yaml:"rpc"`
-		} `yaml:"services"`
-	} `yaml:"reload"`
+				Recursive bool     `mapstructure:"recursive"`
+				Patterns  []string `mapstructure:"patterns"`
+				Dirs      []string `mapstructure:"dirs"`
+			} `mapstructure:"rpc"`
+		} `mapstructure:"services"`
+	} `mapstructure:"reload"`
 }
 
 // ReloadConfig is a Reload configuration point.


### PR DESCRIPTION
Viper doesn't support `yaml` structure tags, it uses `mapstructure`, ref: https://github.com/spf13/viper/issues/385#issuecomment-337264721
Package: https://github.com/mitchellh/mapstructure
This PR replaces all `yaml` tags with `mapstructure`