### PR TITLE
bug(server): Incorrectly set environment variables

### DIFF
--- a/pkg/pipe/pipe_factory_spawn_test.go
+++ b/pkg/pipe/pipe_factory_spawn_test.go
@@ -116,7 +116,7 @@ func Test_Pipe_Failboot2(t *testing.T) {
 	assert.Contains(t, err.Error(), "failboot")
 }
 
-func Test_Pipe_Invalid2t(t *testing.T) {
+func Test_Pipe_Invalid2(t *testing.T) {
 	cmd := exec.Command("php", "../../tests/invalid.php")
 	w, err := NewPipeFactory().SpawnWorker(cmd)
 	assert.Error(t, err)

--- a/plugins/http/plugin.go
+++ b/plugins/http/plugin.go
@@ -33,8 +33,8 @@ const (
 	// PluginName declares plugin name.
 	PluginName = "http"
 
-	// EventInitSSL thrown at moment of https initialization. SSL server passed as context.
-	EventInitSSL = 750
+	// RR_HTTP env variable key (internal) if the HTTP presents
+	RR_HTTP = "RR_HTTP" //nolint:golint,stylecheck
 )
 
 // Middleware interface
@@ -88,6 +88,13 @@ func (s *Plugin) Init(cfg config.Configurer, log logger.Logger, server server.Se
 	if !s.cfg.EnableHTTP() && !s.cfg.EnableTLS() && !s.cfg.EnableFCGI() {
 		return errors.E(op, errors.Disabled)
 	}
+
+	// init if nil
+	if s.cfg.Env == nil {
+		s.cfg.Env = make(map[string]string)
+	}
+
+	s.cfg.Env[RR_HTTP] = "true"
 
 	s.pool, err = server.NewWorkerPool(context.Background(), poolImpl.Config{
 		Debug:           s.cfg.Pool.Debug,

--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -64,6 +64,5 @@ func (z *ZapLogger) ServiceLogger(n endure.Named) (Logger, error) {
 func (z *ZapLogger) Provides() []interface{} {
 	return []interface{}{
 		z.ServiceLogger,
-		z.DefaultLogger,
 	}
 }

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -27,9 +27,7 @@ const PluginName = "server"
 // RR_RELAY env variable key (internal)
 const RR_RELAY = "RR_RELAY" //nolint:golint,stylecheck
 // RR_RPC env variable key (internal) if the RPC presents
-const RR_RPC = "" //nolint:golint,stylecheck
-// RR_HTTP env variable key (internal) if the HTTP presents
-const RR_HTTP = "false" //nolint:golint,stylecheck
+const RR_RPC = "RR_RPC" //nolint:golint,stylecheck
 
 // Plugin manages worker
 type Plugin struct {
@@ -189,10 +187,6 @@ func (server *Plugin) setEnv(e Env) []string {
 		env = append(env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
 	}
 
-	// set internal env variables
-	if server.cfg.HTTP != nil {
-		env = append(env, fmt.Sprintf("%s=%s", RR_HTTP, "true"))
-	}
 	if server.cfg.RPC != nil && server.cfg.RPC.Listen != "" {
 		env = append(env, fmt.Sprintf("%s=%s", RR_RPC, server.cfg.RPC.Listen))
 	}

--- a/tests/plugins/http/response_test.go
+++ b/tests/plugins/http/response_test.go
@@ -75,9 +75,10 @@ func TestNewResponse_Stream(t *testing.T) {
 	// r is pointer, so, it might be nil
 	if r == nil {
 		t.Fatal("response is nil")
+		return
 	}
 
-	r.Body = &bytes.Buffer{}
+	r.Body = new(bytes.Buffer)
 	r.Body.(*bytes.Buffer).WriteString("hello world")
 
 	assert.NoError(t, err)
@@ -99,6 +100,7 @@ func TestNewResponse_StreamError(t *testing.T) {
 	// r is pointer, so, it might be nil
 	if r == nil {
 		t.Fatal("response is nil")
+		return
 	}
 
 	r.Body = &bytes.Buffer{}


### PR DESCRIPTION
This PR fixes the Incorrectly set environment variables in the `server` plugin.
1. `const RR_RPC = "RR_RPC"` (value was empty)
2. `RR_HTTP` moved to the HTTP plugin