### PR TITLE
refactor(http): Uniform debug message from the http hanlder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ uninstall: ## Uninstall locally installed RR
 	rm -f /usr/local/bin/rr
 
 test_coverage:
-	go clean -testcache
 	docker-compose -f tests/docker-compose.yaml up -d
 	rm -rf coverage
 	mkdir coverage
@@ -58,7 +57,6 @@ test_coverage:
 	docker-compose -f tests/docker-compose.yaml down
 
 test: ## Run application tests
-	go clean -testcache
 	docker-compose -f tests/docker-compose.yaml up -d
 	go test -v -race -cover -tags=debug -covermode=atomic ./utils
 	go test -v -race -cover -tags=debug -covermode=atomic ./pkg/pipe

--- a/cmd/cli/workers.go
+++ b/cmd/cli/workers.go
@@ -17,9 +17,8 @@ import (
 	"github.com/spiral/roadrunner/v2/tools"
 )
 
-var (
-	interactive bool
-)
+// use interactive mode
+var interactive bool
 
 const InformerList string = "informer.List"
 const InformerWorkers string = "informer.Workers"
@@ -42,7 +41,7 @@ func init() {
 	root.AddCommand(workersCommand)
 }
 
-func workersHandler(cmd *cobra.Command, args []string) error {
+func workersHandler(_ *cobra.Command, args []string) error {
 	const op = errors.Op("workers cobra handler")
 	// get RPC client
 	client, err := RPCClient()

--- a/plugins/http/plugin.go
+++ b/plugins/http/plugin.go
@@ -115,7 +115,13 @@ func (s *Plugin) Init(cfg config.Configurer, log logger.Logger, server server.Se
 
 func (s *Plugin) logCallback(event interface{}) {
 	if ev, ok := event.(ResponseEvent); ok {
-		s.log.Debug("http handler response received", "elapsed", ev.Elapsed().String(), "remote address", ev.Request.RemoteAddr)
+		s.log.Debug("",
+			"remote", ev.Request.RemoteAddr,
+			"ts", ev.Elapsed().String(),
+			"resp.status", ev.Response.Status,
+			"method", ev.Request.Method,
+			"uri", ev.Request.URI,
+		)
 	}
 }
 

--- a/tests/plugins/http/configs/.rr-resetter.yaml
+++ b/tests/plugins/http/configs/.rr-resetter.yaml
@@ -26,5 +26,5 @@ http:
     destroy_timeout: 60s
 logs:
   mode: development
-  level: debug
+  level: error
 

--- a/tests/plugins/http/configs/.rr-resetter.yaml
+++ b/tests/plugins/http/configs/.rr-resetter.yaml
@@ -26,5 +26,5 @@ http:
     destroy_timeout: 60s
 logs:
   mode: development
-  level: error
+  level: debug
 

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -963,7 +963,7 @@ logs:
 
 	mockLogger.EXPECT().Info("worker destructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Info("worker constructed", "pid", gomock.Any()).MinTimes(1)
-	mockLogger.EXPECT().Debug("http handler response received", "elapsed", gomock.Any(), "remote address", "127.0.0.1").MinTimes(1)
+	mockLogger.EXPECT().Debug("", "remote", gomock.Any(), "ts", gomock.Any(), "resp.status", gomock.Any(), "method", gomock.Any(), "uri", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Info("WORLD", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker event received", "event", events.EventWorkerLog, "worker state", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes() // placeholder for the workerlogerror

--- a/tests/plugins/static/static_plugin_test.go
+++ b/tests/plugins/static/static_plugin_test.go
@@ -304,7 +304,7 @@ func TestStaticFilesForbid(t *testing.T) {
 	mockLogger := mocks.NewMockLogger(controller)
 
 	mockLogger.EXPECT().Info("worker constructed", "pid", gomock.Any()).AnyTimes()
-	mockLogger.EXPECT().Debug("http handler response received", "elapsed", gomock.Any(), "remote address", "127.0.0.1").AnyTimes()
+	mockLogger.EXPECT().Debug("", "remote", gomock.Any(), "ts", gomock.Any(), "resp.status", gomock.Any(), "method", gomock.Any(), "uri", gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Error("file open error", "error", gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes() // placeholder for the workerlogerror
 


### PR DESCRIPTION
# Reason for This PR
Better debug log messages for the http handler
issue #480

## Description of Changes

Update `log.Debug` message structure to include all needed information. Debug messages from the log will be in the form of:
`{"remote": "127.0.0.1", "ts": "3.273883ms", "resp.status": 201, "method": "GET", "uri": "http://localhost:10084/?hello=world"}`
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
