### PR TITLE
ref(configs, debug): update configs, add debug server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ unit_tests
 unit_tests_copied
 dir1
 coverage
+rr

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -31,6 +31,14 @@ http:
         "fc00::/7",
         "fe80::/10",
     ]
+  static:
+    dir: "tests"
+    forbid: [ "" ]
+    request:
+      "input": "custom-header"
+    response:
+      "output": "output-header"
+
   pool:
     num_workers: 6
     max_jobs: 0
@@ -42,7 +50,7 @@ http:
       # TTL defines maximum time worker is allowed to live (seconds)
       ttl: 0
       # IdleTTL defines maximum duration worker can spend in idle mode. Disabled when 0 (seconds)
-      idle_ttl: 100
+      idle_ttl: 10
       # ExecTTL defines maximum lifetime per job (seconds)
       exec_ttl: 10
       # MaxWorkerMemory limits memory per worker (MB)
@@ -57,7 +65,6 @@ http:
   fcgi:
     address: tcp://0.0.0.0:7921
   http2:
-    enabled: false
     h2c: false
     max_concurrent_streams: 128
 
@@ -109,7 +116,6 @@ memcached:
 
 # in memory KV driver
 memory:
-  enabled: true
   # keys ttl check interval
   interval: 60
 

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -31,6 +31,19 @@ http:
         "fc00::/7",
         "fe80::/10",
     ]
+  headers:
+    cors:
+      allowed_origin: "*"
+      allowed_headers: "*"
+      allowed_methods: "GET,POST,PUT,DELETE"
+      allow_credentials: true
+      exposed_headers: "Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma"
+      max_age: 600
+    request:
+      input: "custom-header"
+    response:
+      output: "output-header"
+
   static:
     dir: "tests"
     forbid: [ "" ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/spiral/endure"
 	"github.com/spiral/roadrunner/v2/cmd/cli"
-	"github.com/spiral/roadrunner/v2/plugins/http"
+	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
 	"github.com/spiral/roadrunner/v2/plugins/informer"
 
+	"github.com/spiral/roadrunner/v2/plugins/kv/boltdb"
 	"github.com/spiral/roadrunner/v2/plugins/kv/memcached"
 	"github.com/spiral/roadrunner/v2/plugins/kv/memory"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
@@ -21,7 +22,7 @@ import (
 
 func main() {
 	var err error
-	cli.Container, err = endure.NewContainer(nil, endure.SetLogLevel(endure.ErrorLevel), endure.RetryOnFail(false))
+	cli.Container, err = endure.NewContainer(nil, endure.SetLogLevel(endure.DebugLevel), endure.RetryOnFail(false))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -34,7 +35,7 @@ func main() {
 		// redis plugin (internal)
 		&redis.Plugin{},
 		// http server plugin
-		&http.Plugin{},
+		&httpPlugin.Plugin{},
 		// reload plugin
 		&reload.Plugin{},
 		// informer plugin (./rr workers, ./rr workers -i)
@@ -49,6 +50,8 @@ func main() {
 		&memcached.Plugin{},
 		// in-memory kv plugin
 		&memory.Plugin{},
+		// boltdb driver
+		&boltdb.Plugin{},
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -79,6 +79,7 @@ type Process struct {
 
 // InitBaseWorker creates new Process over given exec.cmd.
 func InitBaseWorker(cmd *exec.Cmd, options ...Options) (worker.BaseProcess, error) {
+	const op = errors.Op("init_base_worker")
 	if cmd.Process != nil {
 		return nil, fmt.Errorf("can't attach to running process")
 	}
@@ -307,9 +308,10 @@ func (w *Process) watch() {
 				n, _ := w.rd.Read(*buf)
 				w.events.Push(events.WorkerEvent{Event: events.EventWorkerLog, Worker: w, Payload: (*buf)[:n]})
 				w.mu.Lock()
+				// delete all prev messages
+				w.stderr.Reset()
 				// write new message
 				w.stderr.Write((*buf)[:n])
-				w.stderr.Reset()
 				w.mu.Unlock()
 				w.put(buf)
 			}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -224,6 +224,8 @@ func (w *Process) Wait() error {
 		w.state.Set(internal.StateStopped)
 	}
 
+	w.stderr.Reset()
+
 	return nil
 }
 
@@ -307,6 +309,7 @@ func (w *Process) watch() {
 				w.mu.Lock()
 				// write new message
 				w.stderr.Write((*buf)[:n])
+				w.stderr.Reset()
 				w.mu.Unlock()
 				w.put(buf)
 			}

--- a/plugins/checker/plugin.go
+++ b/plugins/checker/plugin.go
@@ -27,13 +27,12 @@ type Plugin struct {
 
 func (c *Plugin) Init(log logger.Logger, cfg config.Configurer) error {
 	const op = errors.Op("checker_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.UnmarshalKey(PluginName, &c.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
-	}
-
-	if c.cfg == nil {
-		return errors.E(errors.Disabled)
 	}
 
 	c.registry = make(map[string]Checker)

--- a/plugins/gzip/plugin.go
+++ b/plugins/gzip/plugin.go
@@ -10,6 +10,7 @@ const PluginName = "gzip"
 
 type Gzip struct{}
 
+// needed for the Endure
 func (g *Gzip) Init() error {
 	return nil
 }

--- a/plugins/headers/config.go
+++ b/plugins/headers/config.go
@@ -2,7 +2,7 @@ package headers
 
 // Config declares headers service configuration.
 type Config struct {
-	Headers struct {
+	Headers *struct {
 		// CORS settings.
 		CORS *CORSConfig
 
@@ -17,20 +17,20 @@ type Config struct {
 // CORSConfig headers configuration.
 type CORSConfig struct {
 	// AllowedOrigin: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-	AllowedOrigin string
+	AllowedOrigin string `mapstructure:"allowed_origin"`
 
 	// AllowedHeaders: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
-	AllowedHeaders string
+	AllowedHeaders string `mapstructure:"allowed_headers"`
 
 	// AllowedMethods: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
-	AllowedMethods string
+	AllowedMethods string `mapstructure:"allowed_methods"`
 
 	// AllowCredentials https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
-	AllowCredentials *bool
+	AllowCredentials *bool `mapstructure:"allow_credentials"`
 
 	// ExposeHeaders:  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
-	ExposedHeaders string
+	ExposedHeaders string `mapstructure:"exposed_headers"`
 
 	// MaxAge of CORS headers in seconds/
-	MaxAge int
+	MaxAge int `mapstructure:"max_age"`
 }

--- a/plugins/headers/plugin.go
+++ b/plugins/headers/plugin.go
@@ -22,6 +22,9 @@ type Plugin struct {
 // misconfiguration. Services must not be used without proper configuration pushed first.
 func (s *Plugin) Init(cfg config.Configurer) error {
 	const op = errors.Op("headers_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.UnmarshalKey(RootPluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)

--- a/plugins/headers/plugin.go
+++ b/plugins/headers/plugin.go
@@ -22,12 +22,16 @@ type Plugin struct {
 // misconfiguration. Services must not be used without proper configuration pushed first.
 func (s *Plugin) Init(cfg config.Configurer) error {
 	const op = errors.Op("headers_plugin_init")
-	if !cfg.Has(PluginName) {
+	if !cfg.Has(RootPluginName) {
 		return errors.E(op, errors.Disabled)
 	}
 	err := cfg.UnmarshalKey(RootPluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
+	}
+
+	if s.cfg.Headers == nil {
+		return errors.E(op, errors.Disabled)
 	}
 
 	return nil

--- a/plugins/http/config/fcgi.go
+++ b/plugins/http/config/fcgi.go
@@ -1,0 +1,7 @@
+package config
+
+// FCGI for FastCGI server.
+type FCGI struct {
+	// Address and port to handle as http server.
+	Address string
+}

--- a/plugins/http/config/http2.go
+++ b/plugins/http/config/http2.go
@@ -1,0 +1,28 @@
+package config
+
+// HTTP2 HTTP/2 server customizations.
+type HTTP2 struct {
+	// h2cHandler is a Handler which implements h2c by hijacking the HTTP/1 traffic
+	// that should be h2c traffic. There are two ways to begin a h2c connection
+	// (RFC 7540 Section 3.2 and 3.4): (1) Starting with Prior Knowledge - this
+	// works by starting an h2c connection with a string of bytes that is valid
+	// HTTP/1, but unlikely to occur in practice and (2) Upgrading from HTTP/1 to
+	// h2c - this works by using the HTTP/1 Upgrade header to request an upgrade to
+	// h2c. When either of those situations occur we hijack the HTTP/1 connection,
+	// convert it to a HTTP/2 connection and pass the net.Conn to http2.ServeConn.
+
+	// H2C enables HTTP/2 over TCP
+	H2C bool
+
+	// MaxConcurrentStreams defaults to 128.
+	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams"`
+}
+
+// InitDefaults sets default values for HTTP/2 configuration.
+func (cfg *HTTP2) InitDefaults() error {
+	if cfg.MaxConcurrentStreams == 0 {
+		cfg.MaxConcurrentStreams = 128
+	}
+
+	return nil
+}

--- a/plugins/http/config/ip.go
+++ b/plugins/http/config/ip.go
@@ -1,0 +1,26 @@
+package config
+
+import "net"
+
+// Cidrs is a slice of IPNet addresses
+type Cidrs []*net.IPNet
+
+// IsTrusted checks if the ip address exists in the provided in the config addresses
+func (c *Cidrs) IsTrusted(ip string) bool {
+	if len(*c) == 0 {
+		return false
+	}
+
+	i := net.ParseIP(ip)
+	if i == nil {
+		return false
+	}
+
+	for _, cird := range *c {
+		if cird.Contains(i) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/plugins/http/config/ssl.go
+++ b/plugins/http/config/ssl.go
@@ -1,0 +1,19 @@
+package config
+
+// SSL defines https server configuration.
+type SSL struct {
+	// Port to listen as HTTPS server, defaults to 443.
+	Port int
+
+	// Redirect when enabled forces all http connections to switch to https.
+	Redirect bool
+
+	// Key defined private server key.
+	Key string
+
+	// Cert is https certificate.
+	Cert string
+
+	// Root CA file
+	RootCA string
+}

--- a/plugins/http/config/uploads_config.go
+++ b/plugins/http/config/uploads_config.go
@@ -1,4 +1,4 @@
-package http
+package config
 
 import (
 	"os"
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// UploadsConfig describes file location and controls access to them.
-type UploadsConfig struct {
+// Uploads describes file location and controls access to them.
+type Uploads struct {
 	// Dir contains name of directory to control access to.
 	Dir string
 
@@ -17,14 +17,14 @@ type UploadsConfig struct {
 }
 
 // InitDefaults sets missing values to their default values.
-func (cfg *UploadsConfig) InitDefaults() error {
+func (cfg *Uploads) InitDefaults() error {
 	cfg.Forbid = []string{".php", ".exe", ".bat"}
 	cfg.Dir = os.TempDir()
 	return nil
 }
 
 // TmpDir returns temporary directory.
-func (cfg *UploadsConfig) TmpDir() string {
+func (cfg *Uploads) TmpDir() string {
 	if cfg.Dir != "" {
 		return cfg.Dir
 	}
@@ -33,7 +33,7 @@ func (cfg *UploadsConfig) TmpDir() string {
 }
 
 // Forbids must return true if file extension is not allowed for the upload.
-func (cfg *UploadsConfig) Forbids(filename string) bool {
+func (cfg *Uploads) Forbids(filename string) bool {
 	ext := strings.ToLower(path.Ext(filename))
 
 	for _, v := range cfg.Forbid {

--- a/plugins/http/handler.go
+++ b/plugins/http/handler.go
@@ -12,15 +12,8 @@ import (
 	"github.com/spiral/errors"
 	"github.com/spiral/roadrunner/v2/interfaces/events"
 	"github.com/spiral/roadrunner/v2/interfaces/pool"
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
-)
-
-const (
-	// EventResponse thrown after the request been processed. See ErrorEvent as payload.
-	EventResponse = iota + 500
-
-	// EventError thrown on any non job error provided by road runner server.
-	EventError
 )
 
 // MB is 1024 bytes
@@ -66,8 +59,8 @@ func (e *ResponseEvent) Elapsed() time.Duration {
 // parsed files and query, payload will include parsed form dataTree (if any).
 type Handler struct {
 	maxRequestSize uint64
-	uploads        UploadsConfig
-	trusted        Cidrs
+	uploads        config.Uploads
+	trusted        config.Cidrs
 	log            logger.Logger
 	pool           pool.Pool
 	mul            sync.Mutex
@@ -75,7 +68,7 @@ type Handler struct {
 }
 
 // NewHandler return handle interface implementation
-func NewHandler(maxReqSize uint64, uploads UploadsConfig, trusted Cidrs, pool pool.Pool) (*Handler, error) {
+func NewHandler(maxReqSize uint64, uploads config.Uploads, trusted config.Cidrs, pool pool.Pool) (*Handler, error) {
 	if pool == nil {
 		return nil, errors.E(errors.Str("pool should be initialized"))
 	}

--- a/plugins/http/parse.go
+++ b/plugins/http/parse.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"net/http"
+
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 )
 
 // MaxLevel defines maximum tree depth for incoming request data and files.
@@ -60,7 +62,7 @@ func (d dataTree) mount(i []string, v []string) {
 }
 
 // parse incoming dataTree request into JSON (including contentMultipart form dataTree)
-func parseUploads(r *http.Request, cfg UploadsConfig) *Uploads {
+func parseUploads(r *http.Request, cfg config.Uploads) *Uploads {
 	u := &Uploads{
 		cfg:  cfg,
 		tree: make(fileTree),

--- a/plugins/http/request.go
+++ b/plugins/http/request.go
@@ -11,6 +11,7 @@ import (
 	j "github.com/json-iterator/go"
 	"github.com/spiral/roadrunner/v2/pkg/payload"
 	"github.com/spiral/roadrunner/v2/plugins/http/attributes"
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
 )
 
@@ -70,7 +71,7 @@ func fetchIP(pair string) string {
 }
 
 // NewRequest creates new PSR7 compatible request using net/http request.
-func NewRequest(r *http.Request, cfg UploadsConfig) (*Request, error) {
+func NewRequest(r *http.Request, cfg config.Uploads) (*Request, error) {
 	req := &Request{
 		RemoteAddr: fetchIP(r.RemoteAddr),
 		Protocol:   r.Proto,

--- a/plugins/http/uploads.go
+++ b/plugins/http/uploads.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
 
 	"io"
@@ -30,7 +31,7 @@ const (
 // Uploads tree manages uploaded files tree and temporary files.
 type Uploads struct {
 	// associated temp directory and forbidden extensions.
-	cfg UploadsConfig
+	cfg config.Uploads
 
 	// pre processed data tree for Uploads.
 	tree fileTree
@@ -112,7 +113,7 @@ func NewUpload(f *multipart.FileHeader) *FileUpload {
 // STACK
 // DEFER FILE CLOSE (2)
 // DEFER TMP CLOSE  (1)
-func (f *FileUpload) Open(cfg UploadsConfig) (err error) {
+func (f *FileUpload) Open(cfg config.Uploads) (err error) {
 	if cfg.Forbids(f.Name) {
 		f.Error = UploadErrorExtension
 		return nil

--- a/plugins/kv/boltdb/config.go
+++ b/plugins/kv/boltdb/config.go
@@ -16,9 +16,22 @@ type Config struct {
 
 // InitDefaults initializes default values for the boltdb
 func (s *Config) InitDefaults() {
-	s.Dir = "."          // current dir
-	s.Bucket = "rr"      // default bucket name
-	s.File = "rr.db"     // default file name
-	s.Permissions = 0777 // free for all
-	s.Interval = 60      // default is 60 seconds timeout
+	if s.Dir == "" {
+		s.Dir = "." // current dir
+	}
+	if s.Bucket == "" {
+		s.Bucket = "rr" // default bucket name
+	}
+
+	if s.File == "" {
+		s.File = "rr.db" // default file name
+	}
+
+	if s.Permissions == 0 {
+		s.Permissions = 777 // free for all
+	}
+
+	if s.Interval == 0 {
+		s.Interval = 60 // default is 60 seconds timeout
+	}
 }

--- a/plugins/kv/boltdb/plugin.go
+++ b/plugins/kv/boltdb/plugin.go
@@ -42,14 +42,18 @@ type Plugin struct {
 
 func (s *Plugin) Init(log logger.Logger, cfg config.Configurer) error {
 	const op = errors.Op("boltdb_plugin_init")
-	s.cfg = &Config{}
 
-	s.cfg.InitDefaults()
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 
 	err := cfg.UnmarshalKey(PluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
 	}
+
+	// add default values
+	s.cfg.InitDefaults()
 
 	// set the logger
 	s.log = log

--- a/plugins/kv/memcached/config.go
+++ b/plugins/kv/memcached/config.go
@@ -6,5 +6,7 @@ type Config struct {
 }
 
 func (s *Config) InitDefaults() {
-	s.Addr = []string{"localhost:11211"} // default url for memcached     // init logger
+	if s.Addr == nil {
+		s.Addr = []string{"localhost:11211"} // default url for memcached
+	}
 }

--- a/plugins/kv/memcached/plugin.go
+++ b/plugins/kv/memcached/plugin.go
@@ -36,12 +36,16 @@ func NewMemcachedClient(url string) kv.Storage {
 
 func (s *Plugin) Init(log logger.Logger, cfg config.Configurer) error {
 	const op = errors.Op("memcached_plugin_init")
-	s.cfg = &Config{}
-	s.cfg.InitDefaults()
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.UnmarshalKey(PluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, err)
 	}
+
+	s.cfg.InitDefaults()
+
 	s.log = log
 	return nil
 }

--- a/plugins/kv/memory/config.go
+++ b/plugins/kv/memory/config.go
@@ -2,14 +2,13 @@ package memory
 
 // Config is default config for the in-memory driver
 type Config struct {
-	// Enabled or disabled (true or false)
-	Enabled bool
 	// Interval for the check
 	Interval int
 }
 
 // InitDefaults by default driver is turned off
 func (c *Config) InitDefaults() {
-	c.Enabled = false
-	c.Interval = 60 // seconds
+	if c.Interval == 0 {
+		c.Interval = 60 // seconds
+	}
 }

--- a/plugins/kv/memory/plugin.go
+++ b/plugins/kv/memory/plugin.go
@@ -25,13 +25,15 @@ type Plugin struct {
 
 func (s *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("in_memory_plugin_init")
-	s.cfg = &Config{}
-	s.cfg.InitDefaults()
-
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.UnmarshalKey(PluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, err)
 	}
+
+	s.cfg.InitDefaults()
 	s.log = log
 
 	s.stop = make(chan struct{}, 1)

--- a/plugins/kv/memory/plugin_unit_test.go
+++ b/plugins/kv/memory/plugin_unit_test.go
@@ -17,7 +17,6 @@ func initStorage() kv.Storage {
 		stop: make(chan struct{}),
 	}
 	p.cfg = &Config{
-		Enabled:  true,
 		Interval: 1,
 	}
 

--- a/plugins/logger/plugin.go
+++ b/plugins/logger/plugin.go
@@ -13,13 +13,17 @@ const PluginName = "logs"
 // ZapLogger manages zap logger.
 type ZapLogger struct {
 	base     *zap.Logger
-	cfg      Config
+	cfg      *Config
 	channels ChannelConfig
 }
 
 // Init logger service.
 func (z *ZapLogger) Init(cfg config.Configurer) error {
-	const op = errors.Op("zap logger init")
+	const op = errors.Op("config_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
+
 	err := cfg.UnmarshalKey(PluginName, &z.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)

--- a/plugins/metrics/config.go
+++ b/plugins/metrics/config.go
@@ -134,5 +134,7 @@ func (c *Config) getCollectors() (map[string]prometheus.Collector, error) {
 }
 
 func (c *Config) InitDefaults() {
-
+	if c.Address == "" {
+		c.Address = "localhost:2112"
+	}
 }

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -30,7 +30,7 @@ type statsProvider struct {
 
 // Plugin to manage application metrics using Prometheus.
 type Plugin struct {
-	cfg        Config
+	cfg        *Config
 	log        logger.Logger
 	mu         sync.Mutex // all receivers are pointers
 	http       *http.Server
@@ -41,12 +41,15 @@ type Plugin struct {
 // Init service.
 func (m *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("metrics_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
+
 	err := cfg.UnmarshalKey(PluginName, &m.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
 	}
 
-	// TODO figure out what is Init
 	m.cfg.InitDefaults()
 
 	m.log = log

--- a/plugins/redis/config.go
+++ b/plugins/redis/config.go
@@ -28,5 +28,7 @@ type Config struct {
 
 // InitDefaults initializing fill config with default values
 func (s *Config) InitDefaults() {
-	s.Addrs = []string{"localhost:6379"} // default addr is pointing to local storage
+	if s.Addrs == nil {
+		s.Addrs = []string{"localhost:6379"} // default addr is pointing to local storage
+	}
 }

--- a/plugins/redis/plugin.go
+++ b/plugins/redis/plugin.go
@@ -24,14 +24,17 @@ func (s *Plugin) GetClient() redis.UniversalClient {
 
 func (s *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("redis_plugin_init")
-	s.cfg = &Config{}
-	s.cfg.InitDefaults()
+
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 
 	err := cfg.UnmarshalKey(PluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
 	}
 
+	s.cfg.InitDefaults()
 	s.log = log
 
 	s.universalClient = redis.NewUniversalClient(&redis.UniversalOptions{

--- a/plugins/reload/config.go
+++ b/plugins/reload/config.go
@@ -36,9 +36,13 @@ type ServiceConfig struct {
 }
 
 // InitDefaults sets missing values to their default values.
-func InitDefaults(c *Config) {
-	c.Interval = time.Second
-	c.Patterns = []string{".php"}
+func (c *Config) InitDefaults() {
+	if c.Interval == 0 {
+		c.Interval = time.Second
+	}
+	if c.Patterns == nil {
+		c.Patterns = []string{".php"}
+	}
 }
 
 // Valid validates the configuration.

--- a/plugins/reload/plugin.go
+++ b/plugins/reload/plugin.go
@@ -27,13 +27,17 @@ type Plugin struct {
 // Init controller service
 func (s *Plugin) Init(cfg config.Configurer, log logger.Logger, res resetter.Resetter) error {
 	const op = errors.Op("reload_plugin_init")
-	s.cfg = &Config{}
-	InitDefaults(s.cfg)
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
+
 	err := cfg.UnmarshalKey(PluginName, &s.cfg)
 	if err != nil {
 		// disable plugin in case of error
 		return errors.E(op, errors.Disabled, err)
 	}
+
+	s.cfg.InitDefaults()
 
 	s.log = log
 	s.res = res
@@ -101,7 +105,7 @@ func (s *Plugin) Serve() chan error {
 		}
 	}()
 
-	// map with configs by services
+	// map with config by services
 	updated := make(map[string]ServiceConfig, len(s.cfg.Services))
 
 	go func() {

--- a/plugins/rpc/plugin.go
+++ b/plugins/rpc/plugin.go
@@ -33,7 +33,7 @@ type Plugin struct {
 
 // Init rpc service. Must return true if service is enabled.
 func (s *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
-	const op = errors.Op("rpc plugin init")
+	const op = errors.Op("rpc_plugin_init")
 	if !cfg.Has(PluginName) {
 		return errors.E(op, errors.Disabled)
 	}
@@ -54,7 +54,7 @@ func (s *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 
 // Serve serves the service.
 func (s *Plugin) Serve() chan error {
-	const op = errors.Op("serve rpc plugin")
+	const op = errors.Op("rpc_plugin_serve")
 	errCh := make(chan error, 1)
 
 	s.rpc = rpc.NewServer()
@@ -105,11 +105,12 @@ func (s *Plugin) Serve() chan error {
 
 // Stop stops the service.
 func (s *Plugin) Stop() error {
+	const op = errors.Op("rpc_plugin_stop")
 	// store closed state
 	atomic.StoreUint32(s.closed, 1)
 	err := s.listener.Close()
 	if err != nil {
-		return errors.E(errors.Op("stop RPC socket"), err)
+		return errors.E(op, err)
 	}
 	return nil
 }

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -39,6 +39,9 @@ type Plugin struct {
 // Init application provider.
 func (server *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("server_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.Unmarshal(&server.cfg)
 	if err != nil {
 		return errors.E(op, errors.Init, err)

--- a/plugins/static/config.go
+++ b/plugins/static/config.go
@@ -10,7 +10,7 @@ import (
 
 // Config describes file location and controls access to them.
 type Config struct {
-	Static struct {
+	Static *struct {
 		// Dir contains name of directory to control access to.
 		Dir string
 

--- a/plugins/static/plugin.go
+++ b/plugins/static/plugin.go
@@ -29,9 +29,16 @@ type Plugin struct {
 // misconfiguration. Services must not be used without proper configuration pushed first.
 func (s *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("static_plugin_init")
+	if !cfg.Has(RootPluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	err := cfg.UnmarshalKey(RootPluginName, &s.cfg)
 	if err != nil {
 		return errors.E(op, errors.Disabled, err)
+	}
+
+	if s.cfg.Static == nil {
+		return errors.E(op, errors.Disabled)
 	}
 
 	s.log = log

--- a/tests/plugins/headers/configs/.rr-cors-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-cors-headers.yaml
@@ -8,7 +8,6 @@ server:
   relay_timeout: "20s"
 
 http:
-  debug: true
   address: 127.0.0.1:22855
   max_request_size: 1024
   middleware: [ "headers" ]

--- a/tests/plugins/headers/configs/.rr-cors-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-cors-headers.yaml
@@ -17,16 +17,16 @@ http:
   # Additional HTTP headers and CORS control.
   headers:
     cors:
-      allowedOrigin: "*"
-      allowedHeaders: "*"
-      allowedMethods: "GET,POST,PUT,DELETE"
-      allowCredentials: true
-      exposedHeaders: "Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma"
-      maxAge: 600
+      allowed_origin: "*"
+      allowed_headers: "*"
+      allowed_methods: "GET,POST,PUT,DELETE"
+      allow_credentials: true
+      exposed_headers: "Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma"
+      max_age: 600
     request:
-      "input": "custom-header"
+      input: "custom-header"
     response:
-      "output": "output-header"
+      output: "output-header"
   pool:
     num_workers: 2
     max_jobs: 0

--- a/tests/plugins/headers/configs/.rr-headers-init.yaml
+++ b/tests/plugins/headers/configs/.rr-headers-init.yaml
@@ -8,7 +8,6 @@ server:
   relay_timeout: "20s"
 
 http:
-  debug: true
   address: 127.0.0.1:33453
   max_request_size: 1024
   middleware: [ "headers" ]

--- a/tests/plugins/headers/configs/.rr-headers-init.yaml
+++ b/tests/plugins/headers/configs/.rr-headers-init.yaml
@@ -17,16 +17,16 @@ http:
   # Additional HTTP headers and CORS control.
   headers:
     cors:
-      allowedOrigin: "*"
-      allowedHeaders: "*"
-      allowedMethods: "GET,POST,PUT,DELETE"
-      allowCredentials: true
-      exposedHeaders: "Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma"
-      maxAge: 600
+      allowed_origin: "*"
+      allowed_headers: "*"
+      allowed_methods: "GET,POST,PUT,DELETE"
+      allow_credentials: true
+      exposed_headers: "Cache-Control,Content-Language,Content-Type,Expires,Last-Modified,Pragma"
+      max_age: 600
     request:
-      "Example-Request-Header": "Value"
+      Example-Request-Header: "Value"
     response:
-      "X-Powered-By": "RoadRunner"
+      X-Powered-By: "RoadRunner"
   pool:
     num_workers: 2
     max_jobs: 0

--- a/tests/plugins/headers/configs/.rr-req-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-req-headers.yaml
@@ -8,7 +8,6 @@ server:
   relay_timeout: "20s"
 
 http:
-  debug: true
   address: 127.0.0.1:22655
   max_request_size: 1024
   middleware: [ "headers" ]

--- a/tests/plugins/headers/configs/.rr-req-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-req-headers.yaml
@@ -17,9 +17,9 @@ http:
   # Additional HTTP headers and CORS control.
   headers:
     request:
-      "input": "custom-header"
+      input: "custom-header"
     response:
-      "output": "output-header"
+      output: "output-header"
   pool:
     num_workers: 2
     max_jobs: 0

--- a/tests/plugins/headers/configs/.rr-res-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-res-headers.yaml
@@ -8,7 +8,6 @@ server:
   relay_timeout: "20s"
 
 http:
-  debug: true
   address: 127.0.0.1:22455
   max_request_size: 1024
   middleware: [ "headers" ]

--- a/tests/plugins/headers/configs/.rr-res-headers.yaml
+++ b/tests/plugins/headers/configs/.rr-res-headers.yaml
@@ -17,9 +17,9 @@ http:
   # Additional HTTP headers and CORS control.
   headers:
     request:
-      "input": "custom-header"
+      input: "custom-header"
     response:
-      "output": "output-header"
+      output: "output-header"
   pool:
     num_workers: 2
     max_jobs: 0

--- a/tests/plugins/http/configs/.rr-ssl.yaml
+++ b/tests/plugins/http/configs/.rr-ssl.yaml
@@ -8,7 +8,6 @@ server:
   relay_timeout: "20s"
 
 http:
-  debug: true
   address: :8085
   max_request_size: 1024
   middleware: [ "" ]
@@ -26,13 +25,8 @@ http:
     redirect: false
     cert: fixtures/server.crt
     key: fixtures/server.key
-  #    rootCa: root.crt
   fcgi:
     address: tcp://0.0.0.0:16920
-  http2:
-    enabled: false
-    h2c: false
-    maxConcurrentStreams: 128
 logs:
   mode: development
   level: error

--- a/tests/plugins/http/handler_test.go
+++ b/tests/plugins/http/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spiral/roadrunner/v2/pkg/pipe"
 	poolImpl "github.com/spiral/roadrunner/v2/pkg/pool"
 	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/stretchr/testify/assert"
 
 	"net/http"
@@ -34,7 +35,7 @@ func TestHandler_Echo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -65,7 +66,7 @@ func TestHandler_Echo(t *testing.T) {
 }
 
 func Test_HandlerErrors(t *testing.T) {
-	_, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	_, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, nil)
@@ -88,7 +89,7 @@ func TestHandler_Headers(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -149,7 +150,7 @@ func TestHandler_Empty_User_Agent(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -209,7 +210,7 @@ func TestHandler_User_Agent(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -269,7 +270,7 @@ func TestHandler_Cookies(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -334,7 +335,7 @@ func TestHandler_JsonPayload_POST(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -398,7 +399,7 @@ func TestHandler_JsonPayload_PUT(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -458,7 +459,7 @@ func TestHandler_JsonPayload_PATCH(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -518,7 +519,7 @@ func TestHandler_FormData_POST(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -591,7 +592,7 @@ func TestHandler_FormData_POST_Overwrite(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -664,7 +665,7 @@ func TestHandler_FormData_POST_Form_UrlEncoded_Charset(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -736,7 +737,7 @@ func TestHandler_FormData_PUT(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -808,7 +809,7 @@ func TestHandler_FormData_PATCH(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -880,7 +881,7 @@ func TestHandler_Multipart_POST(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -994,7 +995,7 @@ func TestHandler_Multipart_PUT(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1108,7 +1109,7 @@ func TestHandler_Multipart_PATCH(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1224,7 +1225,7 @@ func TestHandler_Error(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1270,7 +1271,7 @@ func TestHandler_Error2(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1316,7 +1317,7 @@ func TestHandler_Error3(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1375,7 +1376,7 @@ func TestHandler_ResponseDuration(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1436,7 +1437,7 @@ func TestHandler_ResponseDurationDelayed(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1496,7 +1497,7 @@ func TestHandler_ErrorDuration(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -1551,7 +1552,7 @@ func TestHandler_IP(t *testing.T) {
 		"fe80::/10",
 	}
 
-	cidrs, err := httpPlugin.ParseCIDRs(trusted)
+	cidrs, err := config.ParseCIDRs(trusted)
 	assert.NoError(t, err)
 	assert.NotNil(t, cidrs)
 
@@ -1570,7 +1571,7 @@ func TestHandler_IP(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, cidrs, pool)
@@ -1612,7 +1613,7 @@ func TestHandler_XRealIP(t *testing.T) {
 		"fe80::/10",
 	}
 
-	cidrs, err := httpPlugin.ParseCIDRs(trusted)
+	cidrs, err := config.ParseCIDRs(trusted)
 	assert.NoError(t, err)
 	assert.NotNil(t, cidrs)
 
@@ -1631,7 +1632,7 @@ func TestHandler_XRealIP(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, cidrs, pool)
@@ -1678,7 +1679,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		"fe80::/10",
 	}
 
-	cidrs, err := httpPlugin.ParseCIDRs(trusted)
+	cidrs, err := config.ParseCIDRs(trusted)
 	assert.NoError(t, err)
 	assert.NotNil(t, cidrs)
 
@@ -1697,7 +1698,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, cidrs, pool)
@@ -1743,7 +1744,7 @@ func TestHandler_XForwardedFor_NotTrustedRemoteIp(t *testing.T) {
 		"10.0.0.0/8",
 	}
 
-	cidrs, err := httpPlugin.ParseCIDRs(trusted)
+	cidrs, err := config.ParseCIDRs(trusted)
 	assert.NoError(t, err)
 	assert.NotNil(t, cidrs)
 
@@ -1762,7 +1763,7 @@ func TestHandler_XForwardedFor_NotTrustedRemoteIp(t *testing.T) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, cidrs, pool)
@@ -1810,7 +1811,7 @@ func BenchmarkHandler_Listen_Echo(b *testing.B) {
 		pool.Destroy(context.Background())
 	}()
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)

--- a/tests/plugins/http/uploads_config_test.go
+++ b/tests/plugins/http/uploads_config_test.go
@@ -4,12 +4,12 @@ import (
 	"os"
 	"testing"
 
-	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFsConfig_Forbids(t *testing.T) {
-	cfg := httpPlugin.UploadsConfig{Forbid: []string{".php"}}
+	cfg := config.Uploads{Forbid: []string{".php"}}
 
 	assert.True(t, cfg.Forbids("index.php"))
 	assert.True(t, cfg.Forbids("index.PHP"))
@@ -18,9 +18,9 @@ func TestFsConfig_Forbids(t *testing.T) {
 }
 
 func TestFsConfig_TmpFallback(t *testing.T) {
-	cfg := httpPlugin.UploadsConfig{Dir: "test"}
+	cfg := config.Uploads{Dir: "test"}
 	assert.Equal(t, "test", cfg.TmpDir())
 
-	cfg = httpPlugin.UploadsConfig{Dir: ""}
+	cfg = config.Uploads{Dir: ""}
 	assert.Equal(t, os.TempDir(), cfg.TmpDir())
 }

--- a/tests/plugins/http/uploads_test.go
+++ b/tests/plugins/http/uploads_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spiral/roadrunner/v2/pkg/pipe"
 	poolImpl "github.com/spiral/roadrunner/v2/pkg/pool"
 	httpPlugin "github.com/spiral/roadrunner/v2/plugins/http"
+	"github.com/spiral/roadrunner/v2/plugins/http/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,7 +40,7 @@ func TestHandler_Upload_File(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -122,7 +123,7 @@ func TestHandler_Upload_NestedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{},
 	}, nil, pool)
@@ -205,7 +206,7 @@ func TestHandler_Upload_File_NoTmpDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    "-------",
 		Forbid: []string{},
 	}, nil, pool)
@@ -288,7 +289,7 @@ func TestHandler_Upload_File_Forbids(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := httpPlugin.NewHandler(1024, httpPlugin.UploadsConfig{
+	h, err := httpPlugin.NewHandler(1024, config.Uploads{
 		Dir:    os.TempDir(),
 		Forbid: []string{".go"},
 	}, nil, pool)

--- a/tests/plugins/static/config_test.go
+++ b/tests/plugins/static/config_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConfig_Forbids(t *testing.T) {
-	cfg := static.Config{Static: struct {
+	cfg := static.Config{Static: &struct {
 		Dir      string
 		Forbid   []string
 		Always   []string
@@ -23,7 +23,7 @@ func TestConfig_Forbids(t *testing.T) {
 }
 
 func TestConfig_Valid(t *testing.T) {
-	assert.NoError(t, (&static.Config{Static: struct {
+	assert.NoError(t, (&static.Config{Static: &struct {
 		Dir      string
 		Forbid   []string
 		Always   []string
@@ -31,15 +31,15 @@ func TestConfig_Valid(t *testing.T) {
 		Response map[string]string
 	}{Dir: "./"}}).Valid())
 
-	assert.Error(t, (&static.Config{Static: struct {
+	assert.Error(t, (&static.Config{Static: &struct {
 		Dir      string
 		Forbid   []string
 		Always   []string
 		Request  map[string]string
 		Response map[string]string
-	}{Dir: "./config.go"}}).Valid())
+	}{Dir: "./http.go"}}).Valid())
 
-	assert.Error(t, (&static.Config{Static: struct {
+	assert.Error(t, (&static.Config{Static: &struct {
 		Dir      string
 		Forbid   []string
 		Always   []string

--- a/tests/psr-worker-bench.php
+++ b/tests/psr-worker-bench.php
@@ -17,7 +17,6 @@ while ($req = $worker->waitRequest()) {
     try {
         $rsp = new \Nyholm\Psr7\Response();
         $rsp->getBody()->write("hello world");
-        error_log("hello");
         $worker->respond($rsp);
     } catch (\Throwable $e) {
         $worker->getWorker()->error((string)$e);

--- a/tests/psr-worker-bench.php
+++ b/tests/psr-worker-bench.php
@@ -1,28 +1,25 @@
 <?php
-/**
- * @var Goridge\RelayInterface $relay
- */
-use Spiral\Goridge;
+
 use Spiral\RoadRunner;
+use Nyholm\Psr7\Factory;
 
 ini_set('display_errors', 'stderr');
-require __DIR__ . "/vendor/autoload.php";
+include "vendor/autoload.php";
 
-$worker = new RoadRunner\Worker(new Goridge\StreamRelay(STDIN, STDOUT));
-$psr7 = new RoadRunner\Http\PSR7Worker(
-    $worker,
-    new \Nyholm\Psr7\Factory\Psr17Factory(),
-    new \Nyholm\Psr7\Factory\Psr17Factory(),
-    new \Nyholm\Psr7\Factory\Psr17Factory()
+$worker = new RoadRunner\Http\PSR7Worker(
+    RoadRunner\Worker::create(),
+    new Factory\Psr17Factory(),
+    new Factory\Psr17Factory(),
+    new Factory\Psr17Factory()
 );
 
-while ($req = $psr7->waitRequest()) {
+while ($req = $worker->waitRequest()) {
     try {
-        $resp = new \Nyholm\Psr7\Response();
-        $resp->getBody()->write("hello world");
-
-        $psr7->respond($resp);
+        $rsp = new \Nyholm\Psr7\Response();
+        $rsp->getBody()->write("hello world");
+        error_log("hello");
+        $worker->respond($rsp);
     } catch (\Throwable $e) {
-        $psr7->getWorker()->error((string)$e);
+        $worker->getWorker()->error((string)$e);
     }
 }


### PR DESCRIPTION
# Reason for This PR
Stabilization PR
1. Uniform all configs (yaml's)
2. NPE exceptions, when config section is absent
3. HTTP configurations unification
4. Workers stderr memory leak

## Description of Changes
1. Add debug server (when using flag `-d`, debug)
2. Check nil's for all plugin initialization (`config.Has(PluginName)`)
3. Uniform all configs (`.rr.yaml` + configs in the tests)
4. Move HTTP plugin configs (go files) to a separate folder, because there are a lot of them (http2, FCGI, SSL, HTTP, uploads, etc..)
5. Tests update according to changes
6. Reset the stderr buffer when message was sent

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
