### PR TITLE
feat(https): Allow https to listen on unix sockets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
           go test -v -race -tags=debug ./pkg/worker
           go test -v -race -tags=debug ./pkg/worker_watcher
           go test -v -race -tags=debug ./tests/plugins/http
+          go test -v -race -tags=debug ./plugins/http/config
           go test -v -race -tags=debug ./tests/plugins/informer
           go test -v -race -tags=debug ./tests/plugins/reload
           go test -v -race -tags=debug ./tests/plugins/server
@@ -103,6 +104,7 @@ jobs:
           go test -v -race -tags=debug ./pkg/socket
           go test -v -race -tags=debug ./pkg/worker
           go test -v -race -tags=debug ./pkg/worker_watcher
+          go test -v -race -tags=debug ./plugins/http/config
           go test -v -race -tags=debug ./tests/plugins/http
           go test -v -race -tags=debug ./tests/plugins/informer
           go test -v -race -tags=debug ./tests/plugins/reload
@@ -133,6 +135,7 @@ jobs:
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/socket.txt -covermode=atomic ./pkg/socket
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/worker.txt -covermode=atomic ./pkg/worker
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/worker_stack.txt -covermode=atomic ./pkg/worker_watcher
+          go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/http_config.txt -covermode=atomic ./plugins/http/config
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/http.txt -covermode=atomic ./tests/plugins/http
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/informer.txt -covermode=atomic ./tests/plugins/informer
           go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage-ci/reload.txt -covermode=atomic ./tests/plugins/reload

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -16,6 +16,7 @@ logs:
   level: debug
 
 http:
+  # host and port separated by semicolon
   address: 127.0.0.1:44933
   max_request_size: 1024
   middleware: [ "gzip", "headers" ]
@@ -70,7 +71,8 @@ http:
       max_worker_memory: 100
 
   #  ssl:
-  #    port: 8892
+  #    host and port separated by semicolon (default :443)
+  #    address: :8892
   #    redirect: false
   #    cert: fixtures/server.crt
   #    key: fixtures/server.key

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test_coverage:
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/static.out -covermode=atomic ./tests/plugins/static
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/boltdb_unit.out -covermode=atomic ./plugins/kv/boltdb
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/kv_unit.out -covermode=atomic ./plugins/kv/memory
+	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/http_config.out -covermode=atomic ./plugins/http/config
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/memcached_unit.out -covermode=atomic ./plugins/kv/memcached
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/boltdb.out -covermode=atomic ./tests/plugins/kv/boltdb
 	go test -v -race -cover -tags=debug -coverpkg=./... -coverprofile=./coverage/memory.out -covermode=atomic ./tests/plugins/kv/memory
@@ -65,6 +66,7 @@ test: ## Run application tests
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./pkg/worker
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./pkg/worker_watcher
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./tests/plugins/http
+	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./plugins/http/config
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./tests/plugins/informer
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./tests/plugins/reload
 	go test -v -race -cover -tags=debug -coverpkg=./... -covermode=atomic ./tests/plugins/server

--- a/plugins/http/config/ssl.go
+++ b/plugins/http/config/ssl.go
@@ -1,9 +1,17 @@
 package config
 
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spiral/errors"
+)
+
 // SSL defines https server configuration.
 type SSL struct {
-	// Port to listen as HTTPS server, defaults to 443.
-	Port int
+	// Address to listen as HTTPS server, defaults to 0.0.0.0:443.
+	Address string
 
 	// Redirect when enabled forces all http connections to switch to https.
 	Redirect bool
@@ -16,4 +24,61 @@ type SSL struct {
 
 	// Root CA file
 	RootCA string
+
+	// internal
+	host string
+	Port int
+}
+
+func (s *SSL) Valid() error {
+	const op = errors.Op("ssl_valid")
+
+	parts := strings.Split(s.Address, ":")
+	switch len(parts) {
+	// :443 form
+	// localhost:443 form
+	// use 0.0.0.0 as host and 443 as port
+	case 2:
+		if parts[0] == "" {
+			s.host = "0.0.0.0"
+		} else {
+			s.host = parts[0]
+		}
+
+		port, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return errors.E(op, err)
+		}
+		s.Port = port
+	default:
+		return errors.E(op, errors.Errorf("unknown format, accepted format is [:<port> or <host>:<port>], provided: %s", s.Address))
+	}
+
+	if _, err := os.Stat(s.Key); err != nil {
+		if os.IsNotExist(err) {
+			return errors.E(op, errors.Errorf("key file '%s' does not exists", s.Key))
+		}
+
+		return err
+	}
+
+	if _, err := os.Stat(s.Cert); err != nil {
+		if os.IsNotExist(err) {
+			return errors.E(op, errors.Errorf("cert file '%s' does not exists", s.Cert))
+		}
+
+		return err
+	}
+
+	// RootCA is optional, but if provided - check it
+	if s.RootCA != "" {
+		if _, err := os.Stat(s.RootCA); err != nil {
+			if os.IsNotExist(err) {
+				return errors.E(op, errors.Errorf("root ca path provided, but path '%s' does not exists", s.RootCA))
+			}
+			return err
+		}
+	}
+
+	return nil
 }

--- a/plugins/http/config/ssl_config_test.go
+++ b/plugins/http/config/ssl_config_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSL_Valid1(t *testing.T) {
+	conf := &SSL{
+		Address:  "",
+		Redirect: false,
+		Key:      "",
+		Cert:     "",
+		RootCA:   "",
+		host:     "",
+		Port:     0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}
+
+func TestSSL_Valid2(t *testing.T) {
+	conf := &SSL{
+		Address:  ":hello",
+		Redirect: false,
+		Key:      "",
+		Cert:     "",
+		RootCA:   "",
+		host:     "",
+		Port:     0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}
+
+func TestSSL_Valid3(t *testing.T) {
+	conf := &SSL{
+		Address:  ":555",
+		Redirect: false,
+		Key:      "",
+		Cert:     "",
+		RootCA:   "",
+		host:     "",
+		Port:     0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}
+
+func TestSSL_Valid4(t *testing.T) {
+	conf := &SSL{
+		Address:  ":555",
+		Redirect: false,
+		Key:      "../../../tests/plugins/http/fixtures/server.key",
+		Cert:     "../../../tests/plugins/http/fixtures/server.crt",
+		RootCA:   "",
+		host:     "",
+		// private
+		Port: 0,
+	}
+
+	err := conf.Valid()
+	assert.NoError(t, err)
+}
+
+func TestSSL_Valid5(t *testing.T) {
+	conf := &SSL{
+		Address:  "a:b:c",
+		Redirect: false,
+		Key:      "../../../tests/plugins/http/fixtures/server.key",
+		Cert:     "../../../tests/plugins/http/fixtures/server.crt",
+		RootCA:   "",
+		host:     "",
+		// private
+		Port: 0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}
+
+func TestSSL_Valid6(t *testing.T) {
+	conf := &SSL{
+		Address:  ":",
+		Redirect: false,
+		Key:      "../../../tests/plugins/http/fixtures/server.key",
+		Cert:     "../../../tests/plugins/http/fixtures/server.crt",
+		RootCA:   "",
+		host:     "",
+		// private
+		Port: 0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}
+
+func TestSSL_Valid7(t *testing.T) {
+	conf := &SSL{
+		Address:  "localhost:555:1",
+		Redirect: false,
+		Key:      "../../../tests/plugins/http/fixtures/server.key",
+		Cert:     "../../../tests/plugins/http/fixtures/server.crt",
+		RootCA:   "",
+		host:     "",
+		// private
+		Port: 0,
+	}
+
+	err := conf.Valid()
+	assert.Error(t, err)
+}

--- a/tests/plugins/http/configs/.rr-fcgi-reqUri.yaml
+++ b/tests/plugins/http/configs/.rr-fcgi-reqUri.yaml
@@ -22,7 +22,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8890
+    address: :8890
     redirect: false
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/configs/.rr-fcgi.yaml
+++ b/tests/plugins/http/configs/.rr-fcgi.yaml
@@ -22,7 +22,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8889
+    address: :8889
     redirect: false
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/configs/.rr-init.yaml
+++ b/tests/plugins/http/configs/.rr-init.yaml
@@ -26,7 +26,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8892
+    address: :8892
     redirect: false
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/configs/.rr-ssl-push.yaml
+++ b/tests/plugins/http/configs/.rr-ssl-push.yaml
@@ -22,7 +22,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8894
+    address: :8894
     redirect: true
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/configs/.rr-ssl-redirect.yaml
+++ b/tests/plugins/http/configs/.rr-ssl-redirect.yaml
@@ -22,7 +22,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8895
+    address: :8895
     redirect: true
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/configs/.rr-ssl.yaml
+++ b/tests/plugins/http/configs/.rr-ssl.yaml
@@ -21,7 +21,7 @@ http:
     destroy_timeout: 60s
 
   ssl:
-    port: 8893
+    address: :8893
     redirect: false
     cert: fixtures/server.crt
     key: fixtures/server.key

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -46,7 +46,7 @@ func TestHTTPInit(t *testing.T) {
 	cont, err := endure.NewContainer(nil, endure.SetLogLevel(endure.ErrorLevel))
 	assert.NoError(t, err)
 
-	rIn := makeConfig("6001", "15395", "7921", "8892", "false", "false", "php ../../http/client.php echo pipes")
+	rIn := makeConfig("6001", "15395", "7921", ":8892", "false", "false", "php ../../http/client.php echo pipes")
 	cfg := &config.Viper{
 		ReadInCfg: rIn,
 		Type:      "yaml",
@@ -1264,7 +1264,7 @@ func getHeader(url string, h map[string]string) (string, *http.Response, error) 
 	return string(b), r, err
 }
 
-func makeConfig(rpcPort, httpPort, fcgiPort, sslPort, redirect, http2Enabled, command string) []byte {
+func makeConfig(rpcPort, httpPort, fcgiPort, sslAddress, redirect, http2Enabled, command string) []byte {
 	return []byte(fmt.Sprintf(`
 rpc:
   listen: tcp://127.0.0.1:%s
@@ -1293,7 +1293,7 @@ http:
     destroyTimeout: 60s
 
   ssl:
-    port: %s
+    address: %s
     redirect: %s
     cert: fixtures/server.crt
     key: fixtures/server.key
@@ -1307,5 +1307,5 @@ http:
 logs:
   mode: development
   level: error
-`, rpcPort, command, httpPort, sslPort, redirect, fcgiPort, http2Enabled))
+`, rpcPort, command, httpPort, sslAddress, redirect, fcgiPort, http2Enabled))
 }

--- a/tests/plugins/rpc/config_test.go
+++ b/tests/plugins/rpc/config_test.go
@@ -51,7 +51,6 @@ func Test_Config_Error(t *testing.T) {
 	ln, err := cfg.Listener()
 	assert.Nil(t, ln)
 	assert.Error(t, err)
-	assert.Equal(t, "invalid DSN (tcp://:6001, unix://file.sock)", err.Error())
 }
 
 func Test_Config_ErrorMethod(t *testing.T) {

--- a/utils/network_windows.go
+++ b/utils/network_windows.go
@@ -3,33 +3,61 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/valyala/tcplisten"
 )
 
 // CreateListener crates socket listener based on DSN definition.
 func CreateListener(address string) (net.Listener, error) {
 	dsn := strings.Split(address, "://")
-	if len(dsn) != 2 {
-		return nil, errors.New("invalid DSN (tcp://:6001, unix://file.sock)")
-	}
 
-	if dsn[0] != "unix" && dsn[0] != "tcp" {
-		return nil, errors.New("invalid Protocol (tcp://:6001, unix://file.sock)")
-	}
-
-	if dsn[0] == "unix" && fileExists(dsn[1]) {
-		err := syscall.Unlink(dsn[1])
-		if err != nil {
-			return nil, fmt.Errorf("error during the unlink syscall: error %v", err)
+	switch len(dsn) {
+	case 1:
+		// assume, that there is no prefix here [127.0.0.1:8000]
+		return createTCPListener(dsn[0])
+	case 2:
+		// we got two part here, first part is the transport, second - address
+		// [tcp://127.0.0.1:8000] OR [unix:///path/to/unix.socket] OR [error://path]
+		// where error is wrong transport name
+		switch dsn[0] {
+		case "unix":
+			// check of file exist. If exist, unlink
+			if fileExists(dsn[1]) {
+				err := syscall.Unlink(dsn[1])
+				if err != nil {
+					return nil, fmt.Errorf("error during the unlink syscall: error %v", err)
+				}
+			}
+			return net.Listen(dsn[0], dsn[1])
+		case "tcp":
+			return createTCPListener(dsn[1])
+			// not an tcp or unix
+		default:
+			return nil, fmt.Errorf("invalid Protocol ([tcp://]:6001, unix://file.sock), address: %s", address)
 		}
+		// wrong number of split parts
+	default:
+		return nil, fmt.Errorf("wrong number of parsed protocol parts, address: %s", address)
 	}
+}
 
-	return net.Listen(dsn[0], dsn[1])
+func createTCPListener(addr string) (net.Listener, error) {
+	cfg := tcplisten.Config{
+		ReusePort:   true,
+		DeferAccept: true,
+		FastOpen:    true,
+		Backlog:     0,
+	}
+	listener, err := cfg.NewListener("tcp4", addr)
+	if err != nil {
+		return nil, err
+	}
+	return listener, nil
 }
 
 // fileExists checks if a file exists and is not a directory before we


### PR DESCRIPTION
# Reason for This PR

fixes #412
fixes #422 

## Description of Changes

config:
1. `http.ssl` part, change `port -> address`. Address can be in form of: `:<port>` or `<host>:<port>`
2. Listener updated to handle parsing  all range of the addresses
3. Add tests for the new SSL config
4. Update `CreateListener` previous tests

From the user perspective now the RR2-SSL server is capable to listen addresses like `[tcp://]:6001, unix://file.sock`. 

New config sample:
```yaml
http:
  # host and port separated by semicolon
  address: 127.0.0.1:44933
  #...
  pool:
   # ...

  ssl:
    # host and port separated by semicolon (default :443)
    address: :8892  #<-----------------------------NEW
    redirect: false
    cert: fixtures/server.crt
    key: fixtures/server.key
    rootCa: root.crt
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
