### PR TITLE
fix(server): remove command limitaion

### DIFF
--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -85,10 +85,7 @@ func (server *Plugin) CmdFactory(env Env) (func() *exec.Cmd, error) {
 	// create command according to the config
 	cmdArgs = append(cmdArgs, strings.Split(server.cfg.Server.Command, " ")...)
 	if len(cmdArgs) < 2 {
-		return nil, errors.E(op, errors.Str("should be in form of `php <script>"))
-	}
-	if cmdArgs[0] != "php" {
-		return nil, errors.E(op, errors.Str("first arg in command should be `php`"))
+		return nil, errors.E(op, errors.Str("minimum command should be `php <script>"))
 	}
 
 	_, err := os.Stat(cmdArgs[1])

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -85,7 +85,7 @@ func (server *Plugin) CmdFactory(env Env) (func() *exec.Cmd, error) {
 	// create command according to the config
 	cmdArgs = append(cmdArgs, strings.Split(server.cfg.Server.Command, " ")...)
 	if len(cmdArgs) < 2 {
-		return nil, errors.E(op, errors.Str("minimum command should be `php <script>"))
+		return nil, errors.E(op, errors.Str("minimum command should be `<executable> <script>"))
 	}
 
 	_, err := os.Stat(cmdArgs[1])


### PR DESCRIPTION
# Reason for This PR

issue #511 

## Description of Changes

1. Remove command arguments check.
2. Leave the check of command args number. The minimum command should contain 2 args: `<executable> <script>` separated by space.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
