### PR TITLE
bug(screen,race): fix race and workers stdout to screen

### DIFF
--- a/cmd/cli/reset.go
+++ b/cmd/cli/reset.go
@@ -71,7 +71,8 @@ func resetHandler(_ *cobra.Command, args []string) error {
 			defer bar.Increment()
 
 			var done bool
-			err = client.Call(Reset, service, &done)
+			cl := client.Go(Reset, service, &done, nil)
+			<-cl.Done
 			if err != nil {
 				result <- errors.E(op, err)
 				return

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -78,7 +78,7 @@ func init() {
 
 		// if debug mode is on - run debug server
 		if Debug {
-			runDebugServer()
+			go runDebugServer()
 		}
 	})
 }

--- a/cmd/cli/workers.go
+++ b/cmd/cli/workers.go
@@ -84,11 +84,11 @@ func workersHandler(_ *cobra.Command, args []string) error {
 			return nil
 		case <-tt.C:
 			tm.MoveCursor(1, 1)
+			tm.Flush()
 			err := showWorkers(plugins, client)
 			if err != nil {
 				return errors.E(op, err)
 			}
-			tm.Flush()
 		}
 	}
 }


### PR DESCRIPTION
# Reason for This PR

1. Broken `workers -i` command output
2. Race in the RPC call in the `reset` command
3. `-d` flag is broken

## Description of Changes

1. Broken `workers -i` command output
2. Race in the RPC call in the `reset` command
3. Add debug server goroutine (`-d` flag)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
