### PR TITLE
bug(leak): workers memory leak

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,17 +7,17 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [roadrunner-core, roadrunner-binary]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [roadrunner-core, roadrunner-binary]
   schedule:
     - cron: '0 15 * * 6'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -61,9 +61,13 @@ http:
       "output": "output-header"
 
   pool:
+    # default - num of logical CPUs
     num_workers: 6
+    # default 0
     max_jobs: 0
+    # default 1 minute
     allocate_timeout: 60s
+    # default 1 minute
     destroy_timeout: 60s
     supervisor:
       # watch_tick defines how often to check the state of the workers (seconds)

--- a/bors.toml
+++ b/bors.toml
@@ -1,20 +1,14 @@
 status = [
-    'Build (Go 1.14, PHP 7.4, OS ubuntu-latest)',
-    'Build (Go 1.14, PHP 7.4, OS windows-latest)',
-    'Build (Go 1.14, PHP 7.4, OS macos-latest)',
-    'Build (Go 1.15, PHP 7.4, OS ubuntu-latest)',
-    'Build (Go 1.15, PHP 7.4, OS windows-latest)',
-    'Build (Go 1.15, PHP 7.4, OS macos-latest)',
-    'Build (Go 1.14, PHP 8.0, OS ubuntu-latest)',
-    'Build (Go 1.14, PHP 8.0, OS windows-latest)',
-    'Build (Go 1.14, PHP 8.0, OS macos-latest)',
-    'Build (Go 1.15, PHP 8.0, OS ubuntu-latest)',
-    'Build (Go 1.15, PHP 8.0, OS windows-latest)',
-    'Build (Go 1.15, PHP 8.0, OS macos-latest)',
-    'Golang-CI (lint)',
-    'Build docker image',
+    'Linux / Build (Go 1.14, PHP 7.4, OS ubuntu-20.04)',
+    'Linux / Build (Go 1.15, PHP 7.4, OS ubuntu-20.04)',
+    'Linux / Build (Go 1.14, PHP 8.0, OS ubuntu-20.04)',
+    'Linux / Build (Go 1.15, PHP 8.0, OS ubuntu-20.04)',
+    'macOS / Build (Go 1.14, PHP 7.4, OS macos-latest)',
+    'macOS / Build (Go 1.15, PHP 7.4, OS macos-latest)',
+    'macOS / Build (Go 1.14, PHP 8.0, OS macos-latest)',
+    'macOS / Build (Go 1.15, PHP 8.0, OS macos-latest)',
+    'Linux / Golang-CI (lint) ',
 ]
-
 required_approvals = 0
 delete_merged_branches = true
 timeout-sec = 1800

--- a/pkg/events/worker_events.go
+++ b/pkg/events/worker_events.go
@@ -3,9 +3,10 @@ package events
 const (
 	// EventWorkerError triggered after WorkerProcess. Except payload to be error.
 	EventWorkerError W = iota + 11000
-
 	// EventWorkerLog triggered on every write to WorkerProcess StdErr pipe (batched). Except payload to be []byte string.
 	EventWorkerLog
+	// EventWorkerStderr is the worker standard error output
+	EventWorkerStderr
 )
 
 type W int64
@@ -16,6 +17,8 @@ func (ev W) String() string {
 		return "EventWorkerError"
 	case EventWorkerLog:
 		return "EventWorkerLog"
+	case EventWorkerStderr:
+		return "EventWorkerStderr"
 	}
 	return "Unknown event type"
 }

--- a/pkg/pool/static_pool_test.go
+++ b/pkg/pool/static_pool_test.go
@@ -167,7 +167,7 @@ func Test_StaticPool_JobError(t *testing.T) {
 
 func Test_StaticPool_Broken_Replace(t *testing.T) {
 	ctx := context.Background()
-	block := make(chan struct{}, 1)
+	block := make(chan struct{}, 10)
 
 	listener := func(event interface{}) {
 		if wev, ok := event.(events.WorkerEvent); ok {
@@ -491,7 +491,7 @@ func Test_Static_Pool_Slow_Destroy(t *testing.T) {
 
 func Test_StaticPool_NoFreeWorkers(t *testing.T) {
 	ctx := context.Background()
-	block := make(chan struct{}, 1)
+	block := make(chan struct{}, 10)
 
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.PoolEvent); ok {

--- a/pkg/pool/static_pool_test.go
+++ b/pkg/pool/static_pool_test.go
@@ -171,7 +171,7 @@ func Test_StaticPool_Broken_Replace(t *testing.T) {
 
 	listener := func(event interface{}) {
 		if wev, ok := event.(events.WorkerEvent); ok {
-			if wev.Event == events.EventWorkerLog {
+			if wev.Event == events.EventWorkerStderr {
 				e := string(wev.Payload.([]byte))
 				if strings.ContainsAny(e, "undefined_function()") {
 					block <- struct{}{}

--- a/pkg/pool/supervisor_test.go
+++ b/pkg/pool/supervisor_test.go
@@ -210,7 +210,7 @@ func TestSupervisedPool_MaxMemoryReached(t *testing.T) {
 		},
 	}
 
-	block := make(chan struct{}, 1)
+	block := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.PoolEvent); ok {
 			if ev.Event == events.EventMaxMemory {

--- a/pkg/states/worker_states.go
+++ b/pkg/states/worker_states.go
@@ -16,6 +16,7 @@ const (
 	// StateStopping - process is being softly stopped.
 	StateStopping
 
+	// StateKilling - process is being forcibly stopped
 	StateKilling
 
 	// State of worker, when no need to allocate new one
@@ -27,5 +28,6 @@ const (
 	// StateErrored - error WorkerState (can't be used).
 	StateErrored
 
+	// StateRemove - worker is killed and removed from the stack
 	StateRemove
 )

--- a/pkg/transport/pipe/pipe_factory_spawn_test.go
+++ b/pkg/transport/pipe/pipe_factory_spawn_test.go
@@ -106,7 +106,7 @@ func Test_Pipe_PipeError4(t *testing.T) {
 
 func Test_Pipe_Failboot2(t *testing.T) {
 	cmd := exec.Command("php", "../../../tests/failboot.php")
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {

--- a/pkg/transport/pipe/pipe_factory_spawn_test.go
+++ b/pkg/transport/pipe/pipe_factory_spawn_test.go
@@ -106,11 +106,21 @@ func Test_Pipe_PipeError4(t *testing.T) {
 
 func Test_Pipe_Failboot2(t *testing.T) {
 	cmd := exec.Command("php", "../../../tests/failboot.php")
-	w, err := NewPipeFactory().SpawnWorker(cmd)
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "failboot") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+	w, err := NewPipeFactory().SpawnWorker(cmd, listener)
 
 	assert.Nil(t, w)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failboot")
+	<-finish
 }
 
 func Test_Pipe_Invalid2(t *testing.T) {

--- a/pkg/transport/pipe/pipe_factory_test.go
+++ b/pkg/transport/pipe/pipe_factory_test.go
@@ -118,7 +118,7 @@ func Test_Pipe_Failboot(t *testing.T) {
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 	ctx := context.Background()
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {

--- a/pkg/transport/pipe/pipe_factory_test.go
+++ b/pkg/transport/pipe/pipe_factory_test.go
@@ -117,11 +117,23 @@ func Test_Pipe_PipeError2(t *testing.T) {
 func Test_Pipe_Failboot(t *testing.T) {
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 	ctx := context.Background()
-	w, err := NewPipeFactory().SpawnWorkerWithTimeout(ctx, cmd)
+
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "failboot") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+
+	w, err := NewPipeFactory().SpawnWorkerWithTimeout(ctx, cmd, listener)
 
 	assert.Nil(t, w)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failboot")
+	<-finish
 }
 
 func Test_Pipe_Invalid(t *testing.T) {

--- a/pkg/transport/socket/socket_factory_spawn_test.go
+++ b/pkg/transport/socket/socket_factory_spawn_test.go
@@ -110,7 +110,7 @@ func Test_Tcp_Failboot2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {
@@ -162,7 +162,7 @@ func Test_Tcp_Broken2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/client.php", "broken", "tcp")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {
@@ -274,7 +274,7 @@ func Test_Unix_Failboot2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {
@@ -332,7 +332,7 @@ func Test_Unix_Broken2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/client.php", "broken", "unix")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {

--- a/pkg/transport/socket/socket_factory_spawn_test.go
+++ b/pkg/transport/socket/socket_factory_spawn_test.go
@@ -3,11 +3,13 @@ package socket
 import (
 	"net"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/spiral/roadrunner/v2/pkg/events"
 	"github.com/spiral/roadrunner/v2/pkg/payload"
 	"github.com/spiral/roadrunner/v2/pkg/worker"
 	"github.com/stretchr/testify/assert"
@@ -108,10 +110,21 @@ func Test_Tcp_Failboot2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	w, err2 := NewSocketServer(ls, time.Second*5).SpawnWorker(cmd)
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "failboot") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+
+	w, err2 := NewSocketServer(ls, time.Second*5).SpawnWorker(cmd, listener)
 	assert.Nil(t, w)
 	assert.Error(t, err2)
-	assert.Contains(t, err2.Error(), "failboot")
+	<-finish
 }
 
 func Test_Tcp_Invalid2(t *testing.T) {
@@ -149,7 +162,18 @@ func Test_Tcp_Broken2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/client.php", "broken", "tcp")
 
-	w, err := NewSocketServer(ls, time.Minute).SpawnWorker(cmd)
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "undefined_function()") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+
+	w, err := NewSocketServer(ls, time.Minute).SpawnWorker(cmd, listener)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +183,6 @@ func Test_Tcp_Broken2(t *testing.T) {
 		defer wg.Done()
 		err := w.Wait()
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "undefined_function()")
 	}()
 
 	defer func() {
@@ -176,6 +199,7 @@ func Test_Tcp_Broken2(t *testing.T) {
 	assert.Nil(t, res.Body)
 	assert.Nil(t, res.Context)
 	wg.Wait()
+	<-finish
 }
 
 func Test_Tcp_Echo2(t *testing.T) {
@@ -250,10 +274,21 @@ func Test_Unix_Failboot2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	w, err := NewSocketServer(ls, time.Second*5).SpawnWorker(cmd)
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "failboot") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+
+	w, err := NewSocketServer(ls, time.Second*5).SpawnWorker(cmd, listener)
 	assert.Nil(t, w)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failboot")
+	<-finish
 }
 
 func Test_Unix_Timeout2(t *testing.T) {
@@ -297,7 +332,18 @@ func Test_Unix_Broken2(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/client.php", "broken", "unix")
 
-	w, err := NewSocketServer(ls, time.Minute).SpawnWorker(cmd)
+	finish := make(chan struct{}, 1)
+	listener := func(event interface{}) {
+		if ev, ok := event.(events.WorkerEvent); ok {
+			if ev.Event == events.EventWorkerStderr {
+				if strings.Contains(string(ev.Payload.([]byte)), "undefined_function()") {
+					finish <- struct{}{}
+				}
+			}
+		}
+	}
+
+	w, err := NewSocketServer(ls, time.Minute).SpawnWorker(cmd, listener)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +353,6 @@ func Test_Unix_Broken2(t *testing.T) {
 		defer wg.Done()
 		err := w.Wait()
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "undefined_function()")
 	}()
 
 	defer func() {
@@ -324,6 +369,7 @@ func Test_Unix_Broken2(t *testing.T) {
 	assert.Nil(t, res.Context)
 	assert.Nil(t, res.Body)
 	wg.Wait()
+	<-finish
 }
 
 func Test_Unix_Echo2(t *testing.T) {

--- a/pkg/transport/socket/socket_factory_test.go
+++ b/pkg/transport/socket/socket_factory_test.go
@@ -120,7 +120,7 @@ func Test_Tcp_Failboot(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {
@@ -199,7 +199,7 @@ func Test_Tcp_Broken(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/client.php", "broken", "tcp")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {
@@ -325,7 +325,7 @@ func Test_Unix_Failboot(t *testing.T) {
 
 	cmd := exec.Command("php", "../../../tests/failboot.php")
 
-	finish := make(chan struct{}, 1)
+	finish := make(chan struct{}, 10)
 	listener := func(event interface{}) {
 		if ev, ok := event.(events.WorkerEvent); ok {
 			if ev.Event == events.EventWorkerStderr {

--- a/pkg/worker/sync_worker.go
+++ b/pkg/worker/sync_worker.go
@@ -36,10 +36,8 @@ func FromSync(w *SyncWorkerImpl) BaseProcess {
 		state:    w.process.state,
 		cmd:      w.process.cmd,
 		pid:      w.process.pid,
-		stderr:   w.process.stderr,
 		endState: w.process.endState,
 		relay:    w.process.relay,
-		rd:       w.process.rd,
 	}
 }
 

--- a/plugins/informer/rpc.go
+++ b/plugins/informer/rpc.go
@@ -26,7 +26,6 @@ func (rpc *rpc) List(_ bool, list *[]string) error {
 		*list = append(*list, name)
 	}
 	rpc.log.Debug("list of services", "list", *list)
-
 	rpc.log.Debug("successfully finished List method")
 	return nil
 }

--- a/plugins/server/plugin.go
+++ b/plugins/server/plugin.go
@@ -234,12 +234,12 @@ func (server *Plugin) collectEvents(event interface{}) {
 	if we, ok := event.(events.WorkerEvent); ok {
 		switch we.Event {
 		case events.EventWorkerError:
-			server.log.Error(we.Payload.(error).Error(), "pid", we.Worker.(worker.BaseProcess).Pid())
-		case events.EventWorkerStderr:
-			// TODO unsafe byte to string convertation
-			server.log.Debug("worker stderr", "pid", we.Worker.(worker.BaseProcess).Pid(), "message", string(we.Payload.([]byte)))
+			server.log.Error(strings.TrimRight(we.Payload.(error).Error(), " \n\t"))
 		case events.EventWorkerLog:
-			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"), "pid", we.Worker.(worker.BaseProcess).Pid())
+			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"))
+		case events.EventWorkerStderr:
+			// TODO unsafe byte to string convert
+			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"))
 		}
 	}
 }
@@ -248,12 +248,12 @@ func (server *Plugin) collectWorkerLogs(event interface{}) {
 	if we, ok := event.(events.WorkerEvent); ok {
 		switch we.Event {
 		case events.EventWorkerError:
-			server.log.Error(we.Payload.(error).Error(), "pid", we.Worker.(worker.BaseProcess).Pid())
+			server.log.Error(strings.TrimRight(we.Payload.(error).Error(), " \n\t"))
 		case events.EventWorkerLog:
-			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"), "pid", we.Worker.(worker.BaseProcess).Pid())
+			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"))
 		case events.EventWorkerStderr:
-			// TODO unsafe byte to string convertation
-			server.log.Debug("worker stderr", "pid", we.Worker.(worker.BaseProcess).Pid(), "message", string(we.Payload.([]byte)))
+			// TODO unsafe byte to string convert
+			server.log.Debug(strings.TrimRight(string(we.Payload.([]byte)), " \n\t"))
 		}
 	}
 }

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,10 +1,11 @@
 {
-  "minimum-stability": "dev",
+  "minimum-stability": "beta",
   "prefer-stable": true,
   "require": {
     "nyholm/psr7": "^1.3",
     "spiral/roadrunner": "^2.0",
     "spiral/roadrunner-http": "^2.0",
-    "temporal/sdk": "dev-master"
+    "temporal/sdk": ">=1.0",
+    "spiral/tokenizer": ">=2.7"
   }
 }

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -1025,6 +1025,7 @@ logs:
 	controller := gomock.NewController(t)
 	mockLogger := mocks.NewMockLogger(controller)
 
+	mockLogger.EXPECT().Debug("worker stderr", "pid", gomock.Any(), "message", gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Debug("worker destructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker constructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("", "remote", gomock.Any(), "ts", gomock.Any(), "resp.status", gomock.Any(), "method", gomock.Any(), "uri", gomock.Any()).MinTimes(1)

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -1025,7 +1025,7 @@ logs:
 	controller := gomock.NewController(t)
 	mockLogger := mocks.NewMockLogger(controller)
 
-	mockLogger.EXPECT().Debug("worker stderr", "pid", gomock.Any(), "message", gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Debug("worker destructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker constructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("", "remote", gomock.Any(), "ts", gomock.Any(), "resp.status", gomock.Any(), "method", gomock.Any(), "uri", gomock.Any()).MinTimes(1)

--- a/tests/plugins/reload/reload_plugin_test.go
+++ b/tests/plugins/reload/reload_plugin_test.go
@@ -358,7 +358,7 @@ func reloadFilteredExt(t *testing.T) {
 }
 
 // Should be events only about creating files with txt ext
-func TestReloadCopy500(t *testing.T) {
+func TestReloadCopy100(t *testing.T) {
 	cont, err := endure.NewContainer(nil, endure.SetLogLevel(endure.ErrorLevel))
 	assert.NoError(t, err)
 
@@ -447,16 +447,16 @@ func TestReloadCopy500(t *testing.T) {
 
 	// Scenario
 	// 1
-	// Create 3k files with txt, abc, def extensions
+	// Create 100 files with txt, abc, def extensions
 	// Copy files to the unit_tests_copy dir
 	// 2
 	// Delete both dirs, recreate
-	// Create 3k files with txt, abc, def extensions
+	// Create 100 files with txt, abc, def extensions
 	// Move files to the unit_tests_copy dir
 	// 3
 	// Recursive
 
-	t.Run("ReloadMake300Files", reloadMake300Files)
+	t.Run("ReloadMake100Files", reloadMake100Files)
 	t.Run("ReloadCopyFiles", reloadCopyFiles)
 	t.Run("ReloadRecursiveDirsSupport", copyFilesRecursive)
 	t.Run("RandomChangesInRecursiveDirs", randomChangesInRecursiveDirs)
@@ -478,9 +478,9 @@ func reloadMoveSupport(t *testing.T) {
 		// rand sleep
 		rSleep := rand.Int63n(500) // nolint:gosec
 		time.Sleep(time.Millisecond * time.Duration(rSleep))
-		rNum := rand.Int63n(int64(100)) // nolint:gosec
-		rDir := rand.Int63n(9)          // nolint:gosec
-		rExt := rand.Int63n(3)          // nolint:gosec
+		rNum := rand.Int63n(int64(33)) // nolint:gosec
+		rDir := rand.Int63n(9)         // nolint:gosec
+		rExt := rand.Int63n(3)         // nolint:gosec
 
 		ext := []string{
 			".txt",
@@ -570,7 +570,7 @@ func randomChangesInRecursiveDirs(t *testing.T) {
 	}
 	for i := 0; i < 10; i++ {
 		// rand sleep
-		rSleep := rand.Int63n(500) // nolint:gosec
+		rSleep := rand.Int63n(100) // nolint:gosec
 		time.Sleep(time.Millisecond * time.Duration(rSleep))
 		rNum := rand.Int63n(int64(100)) // nolint:gosec
 		rDir := rand.Int63n(10)         // nolint:gosec
@@ -616,13 +616,13 @@ func reloadCopyFiles(t *testing.T) {
 	assert.NoError(t, os.Mkdir(testCopyToDir, 0755))
 
 	// recreate files
-	for i := uint(0); i < 100; i++ {
+	for i := uint(0); i < 33; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".txt"))
 	}
-	for i := uint(0); i < 100; i++ {
+	for i := uint(0); i < 33; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".abc"))
 	}
-	for i := uint(0); i < 100; i++ {
+	for i := uint(0); i < 34; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".def"))
 	}
 
@@ -630,14 +630,14 @@ func reloadCopyFiles(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func reloadMake300Files(t *testing.T) {
-	for i := uint(0); i < 100; i++ {
+func reloadMake100Files(t *testing.T) {
+	for i := uint(0); i < 33; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".txt"))
 	}
-	for i := uint(0); i < 100; i++ {
+	for i := uint(0); i < 33; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".abc"))
 	}
-	for i := uint(0); i < 100; i++ {
+	for i := uint(0); i < 34; i++ {
 		assert.NoError(t, makeFile("file_"+strconv.Itoa(int(i))+".def"))
 	}
 }


### PR DESCRIPTION
# Reason for This PR

1. Leaking workers on `Reset` doesn't free resources holding a pointer to the stderr buffer.
2. Create a new `EventWorkerStderr` event which would be responsible for handling all `stderr` events and send them to the listener.

## Description of Changes

1. New event in the `pkg/events`
2. Remove all buffers, pools, pipes, mutexes from the `Worker`. Only `4.5MB` inuse-space objects for all worker (golang) lifetime.
3. Stderr events sending only via listeners. No dangling pointers after workers destroyed which prevent GC to free up resources.
4. Update `bors.toml` according to the new actions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
