### PR TITLE
🆕 new(http plugin): HTTP/HTTPS/FCGI servers errors redirected to the RR logger under the Error log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+v2.0.1 (23.03.2021)
+-------------------
+- 🐛 Fix: Bug with required Root CA certificate for the SSL, not it's optional.
+- 🆕 New: HTTP/FCGI/HTTPS internal logs instead of going to the raw stdout will be displayed in the RR logger at the `Info` log level.
+
 v2.0.1 (09.03.2021)
 -------------------
 - 🐛 Fix: incorrect PHP command validation

--- a/plugins/logger/interface.go
+++ b/plugins/logger/interface.go
@@ -1,14 +1,12 @@
 package logger
 
-type (
-	// Logger is an general RR log interface
-	Logger interface {
-		Debug(msg string, keyvals ...interface{})
-		Info(msg string, keyvals ...interface{})
-		Warn(msg string, keyvals ...interface{})
-		Error(msg string, keyvals ...interface{})
-	}
-)
+// Logger is an general RR log interface
+type Logger interface {
+	Debug(msg string, keyvals ...interface{})
+	Info(msg string, keyvals ...interface{})
+	Warn(msg string, keyvals ...interface{})
+	Error(msg string, keyvals ...interface{})
+}
 
 // With creates a child logger and adds structured context to it
 type WithLogger interface {

--- a/plugins/logger/std_log_adapter.go
+++ b/plugins/logger/std_log_adapter.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"unsafe"
+)
+
+// StdLogAdapter can be passed to the http.Server or any place which required standard logger to redirect output
+// to the logger plugin
+type StdLogAdapter struct {
+	log Logger
+}
+
+// Write io.Writer interface implementation
+func (s *StdLogAdapter) Write(p []byte) (n int, err error) {
+	s.log.Info("server internal stderr", "message", toString(p))
+	return len(p), nil
+}
+
+// NewStdAdapter constructs StdLogAdapter
+func NewStdAdapter(log Logger) *StdLogAdapter {
+	logAdapter := &StdLogAdapter{
+		log: log,
+	}
+
+	return logAdapter
+}
+
+// unsafe, but lightning fast []byte to string conversion
+func toString(data []byte) string {
+	return *(*string)(unsafe.Pointer(&data))
+}

--- a/plugins/logger/std_log_adapter.go
+++ b/plugins/logger/std_log_adapter.go
@@ -12,7 +12,7 @@ type StdLogAdapter struct {
 
 // Write io.Writer interface implementation
 func (s *StdLogAdapter) Write(p []byte) (n int, err error) {
-	s.log.Info("server internal stderr", "message", toString(p))
+	s.log.Error("server internal error", "message", toString(p))
 	return len(p), nil
 }
 

--- a/tests/plugins/http/configs/.rr-h2c.yaml
+++ b/tests/plugins/http/configs/.rr-h2c.yaml
@@ -24,5 +24,6 @@ http:
     h2c: true
     maxConcurrentStreams: 128
 logs:
-  mode: development
-  level: error
+  mode: production
+  level: info
+  encoding: console

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -708,7 +708,7 @@ func TestH2CUpgrade(t *testing.T) {
 	controller := gomock.NewController(t)
 	mockLogger := mocks.NewMockLogger(controller)
 
-	mockLogger.EXPECT().Info("server internal stderr", "message", gomock.Any()).MinTimes(1)
+	mockLogger.EXPECT().Error("server internal error", "message", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker destructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker constructed", "pid", gomock.Any()).MinTimes(1)
 	mockLogger.EXPECT().Debug("worker event received", "event", events.EventWorkerLog, "worker state", gomock.Any()).MinTimes(1)

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -705,11 +705,18 @@ func TestH2CUpgrade(t *testing.T) {
 		Path:   "configs/.rr-h2c.yaml",
 		Prefix: "rr",
 	}
+	controller := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(controller)
+
+	mockLogger.EXPECT().Info("server internal stderr", "message", gomock.Any()).MinTimes(1)
+	mockLogger.EXPECT().Debug("worker destructed", "pid", gomock.Any()).MinTimes(1)
+	mockLogger.EXPECT().Debug("worker constructed", "pid", gomock.Any()).MinTimes(1)
+	mockLogger.EXPECT().Debug("worker event received", "event", events.EventWorkerLog, "worker state", gomock.Any()).MinTimes(1)
 
 	err = cont.RegisterAll(
 		cfg,
 		&rpcPlugin.Plugin{},
-		&logger.ZapLogger{},
+		mockLogger,
 		&server.Plugin{},
 		&httpPlugin.Plugin{},
 	)


### PR DESCRIPTION
# Reason for This PR

closes #585 

## Description of Changes

- 🧑‍🏭  Add the ability to print http/https/fcgi to the RR logger under the `ERROR` log level
- 🔴 Redirected errors are: accepting connections, unexpected behavior from handlers, and underlying FileSystem errors

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
