### PR TITLE
fix(metrics): remove statsProvider from metrics collectors sync.Map

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,14 +1,6 @@
 name: Linters
 
-on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      - "**:**"
+on: [push, pull_request]
 
 jobs:
   golangci-lint:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,14 +1,6 @@
 name: Tests
 
-on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      - "**:**"
+on: [push, pull_request]
 
 jobs:
   golang:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 v2.0.2 (06.04.2021)
 -------------------
 - 🐛 Fix: Bug with required Root CA certificate for the SSL, now it's optional.
-- 🐛 Fix: Bug with incorrectly consuming metrics collector from the RPC calls.
+- 🐛 Fix: Bug with incorrectly consuming metrics collector from the RPC calls (thanks @dstrop).
 - 🆕 New: HTTP/FCGI/HTTPS internal logs instead of going to the raw stdout will be displayed in the RR logger at
   the `Info` log level.
 - ⚡ New: Builds for the Mac with the M1 processor (arm64).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ CHANGELOG
 
 v2.0.2 (06.04.2021)
 -------------------
-- 🐛 Fix: Bug with required Root CA certificate for the SSL, not it's optional.
-- 🆕 New: HTTP/FCGI/HTTPS internal logs instead of going to the raw stdout will be displayed in the RR logger at the `Info` log level.
-
+- 🐛 Fix: Bug with required Root CA certificate for the SSL, now it's optional.
+- 🐛 Fix: Bug with incorrectly consuming metrics collector from the RPC calls.
+- 🆕 New: HTTP/FCGI/HTTPS internal logs instead of going to the raw stdout will be displayed in the RR logger at
+  the `Info` log level.
+- ⚡ New: Builds for the Mac with the M1 processor (arm64).
+- 👷 Rework ServeHTTP handler logic. Use http.Error instead of writing code directly to the response writer. Other small
+  improvements.
+  
 v2.0.1 (09.03.2021)
 -------------------
 - 🐛 Fix: incorrect PHP command validation

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -23,11 +23,6 @@ const (
 	maxHeaderSize = 1024 * 1024 * 100 // 104MB
 )
 
-type statsProvider struct {
-	collectors []prometheus.Collector
-	name       string
-}
-
 // Plugin to manage application metrics using Prometheus.
 type Plugin struct {
 	cfg        *Config
@@ -74,16 +69,14 @@ func (m *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 
 	// Register invocation will be later in the Serve method
 	for k, v := range collectors {
-		m.collectors.Store(k, statsProvider{
-			collectors: []prometheus.Collector{v},
-			name:       k,
-		})
+		m.collectors.Store(k, v)
 	}
 	return nil
 }
 
 // Register new prometheus collector.
-func (m *Plugin) Register(c prometheus.Collector) error {
+func (m *Plugin) Register(c
+) error {
 	return m.registry.Register(c)
 }
 
@@ -92,13 +85,11 @@ func (m *Plugin) Serve() chan error {
 	errCh := make(chan error, 1)
 	m.collectors.Range(func(key, value interface{}) bool {
 		// key - name
-		// value - statsProvider struct
-		c := value.(statsProvider)
-		for _, v := range c.collectors {
-			if err := m.registry.Register(v); err != nil {
-				errCh <- err
-				return false
-			}
+		// value - prometheus.Collector
+		c := value.(prometheus.Collector)
+		if err := m.registry.Register(c); err != nil {
+			errCh <- err
+			return false
 		}
 
 		return true
@@ -211,10 +202,13 @@ func (m *Plugin) Collects() []interface{} {
 
 // Collector returns application specific collector by name or nil if collector not found.
 func (m *Plugin) AddStatProvider(name endure.Named, stat StatProvider) error {
-	m.collectors.Store(name.Name(), statsProvider{
-		collectors: stat.MetricsCollector(),
-		name:       name.Name(),
-	})
+	for _, c := range stat.MetricsCollector() {
+		err := m.registry.Register(c)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -75,8 +75,7 @@ func (m *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 }
 
 // Register new prometheus collector.
-func (m *Plugin) Register(c
-) error {
+func (m *Plugin) Register(c prometheus.Collector) error {
 	return m.registry.Register(c)
 }
 

--- a/tests/plugins/metrics/.rr-test.yaml
+++ b/tests/plugins/metrics/.rr-test.yaml
@@ -10,6 +10,9 @@ metrics:
       help: "Custom application metric"
       labels: [ "type" ]
       buckets: [ 0.1, 0.2, 0.3, 1.0 ]
+    app_metric_counter:
+      type: counter
+      help: "Custom application counter."
 logs:
   mode: development
   level: error


### PR DESCRIPTION
# Reason for This PR

metrics configured through config file are currently not working
see #571

## Description of Changes

metrics from other plugins are no longer stored in `collectors` `sync.Map`
but instead they are direcly registered into `prometheus.Registry`
ensuring only `prometheus.Collector` is stored in `collectors`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
