### PR TITLE
[WIP] feat(informer): list of active plugin in runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,7 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2
 )
+
+replace (
+	github.com/spiral/endure v1.0.1 => ../endure
+)

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,3 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2
 )
-
-replace (
-	github.com/spiral/endure v1.0.1 => ../endure
-)

--- a/plugins/config/plugin.go
+++ b/plugins/config/plugin.go
@@ -113,9 +113,14 @@ func (v *Viper) Has(name string) bool {
 	return v.viper.IsSet(name)
 }
 
-// Returns common config parameters
+// GetCommonConfig Returns common config parameters
 func (v *Viper) GetCommonConfig() *General {
 	return v.CommonConfig
+}
+
+// Available interface implementation
+func (v *Viper) Available() bool {
+	return true
 }
 
 func parseFlag(flag string) (string, string, error) {

--- a/plugins/gzip/plugin.go
+++ b/plugins/gzip/plugin.go
@@ -10,7 +10,7 @@ const PluginName = "gzip"
 
 type Plugin struct{}
 
-// needed for the Endure
+// Init needed for the Endure
 func (g *Plugin) Init() error {
 	return nil
 }
@@ -19,6 +19,11 @@ func (g *Plugin) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gziphandler.GzipHandler(next).ServeHTTP(w, r)
 	})
+}
+
+// Available interface implementation
+func (g *Plugin) Available() bool {
+	return true
 }
 
 func (g *Plugin) Name() string {

--- a/plugins/headers/plugin.go
+++ b/plugins/headers/plugin.go
@@ -8,11 +8,11 @@ import (
 	"github.com/spiral/roadrunner/v2/plugins/config"
 )
 
-// ID contains default service name.
+// PluginName contains default service name.
 const PluginName = "headers"
 const RootPluginName = "http"
 
-// Service serves headers files. Potentially convert into middleware?
+// Plugin serves headers files. Potentially convert into middleware?
 type Plugin struct {
 	// server configuration (location, forbidden files and etc)
 	cfg *Config
@@ -37,7 +37,7 @@ func (s *Plugin) Init(cfg config.Configurer) error {
 	return nil
 }
 
-// middleware must return true if request/response pair is handled within the middleware.
+// Middleware is HTTP plugin middleware to serve headers
 func (s *Plugin) Middleware(next http.Handler) http.Handler {
 	// Define the http.HandlerFunc
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +67,11 @@ func (s *Plugin) Middleware(next http.Handler) http.Handler {
 
 func (s *Plugin) Name() string {
 	return PluginName
+}
+
+// Available interface implementation
+func (s *Plugin) Available() bool {
+	return true
 }
 
 // configure OPTIONS response

--- a/plugins/http/plugin.go
+++ b/plugins/http/plugin.go
@@ -440,3 +440,8 @@ func (s *Plugin) Ready() status.Status {
 		Code: http.StatusServiceUnavailable,
 	}
 }
+
+// Available interface implementation
+func (s *Plugin) Available() bool {
+	return true
+}

--- a/plugins/informer/interface.go
+++ b/plugins/informer/interface.go
@@ -4,13 +4,18 @@ import (
 	"github.com/spiral/roadrunner/v2/pkg/process"
 )
 
+/*
+Informer plugin should not receive any other plugin in the Init or via Collects
+Because Availabler implementation should present in every plugin
+*/
+
 // Informer used to get workers from particular plugin or set of plugins
 type Informer interface {
 	Workers() []process.State
 }
 
-// Lister interface used to filter available plugins
-type Lister interface {
-	// List gets no args, but returns list of the active plugins
-	List() []string
+// Availabler interface should be implemented by every plugin which wish to report to the PHP worker that it available in the RR runtime
+type Availabler interface {
+	// Available returns true if the particular plugin available in the RR2 runtime
+	Available() bool
 }

--- a/plugins/informer/interface.go
+++ b/plugins/informer/interface.go
@@ -8,3 +8,9 @@ import (
 type Informer interface {
 	Workers() []process.State
 }
+
+// Lister interface used to filter available plugins
+type Lister interface {
+	// List gets no args, but returns list of the active plugins
+	List() []string
+}

--- a/plugins/informer/plugin.go
+++ b/plugins/informer/plugin.go
@@ -11,6 +11,7 @@ const PluginName = "informer"
 
 type Plugin struct {
 	registry map[string]Informer
+	plugins  map[string]Lister
 	log      logger.Logger
 }
 
@@ -31,17 +32,22 @@ func (p *Plugin) Workers(name string) ([]process.State, error) {
 	return svc.Workers(), nil
 }
 
-// CollectTarget resettable service.
-func (p *Plugin) CollectTarget(name endure.Named, r Informer) error {
-	p.registry[name.Name()] = r
-	return nil
-}
-
 // Collects declares services to be collected.
 func (p *Plugin) Collects() []interface{} {
 	return []interface{}{
-		p.CollectTarget,
+		p.CollectWorkers,
 	}
+}
+
+// CollectPlugins collects all RR plugins
+func (p *Plugin) CollectPlugins(name endure.Named, l Lister) {
+	p.plugins[name.Name()] = l
+}
+
+// CollectWorkers obtains plugins with workers inside.
+func (p *Plugin) CollectWorkers(name endure.Named, r Informer) error {
+	p.registry[name.Name()] = r
+	return nil
 }
 
 // Name of the service.

--- a/plugins/informer/rpc.go
+++ b/plugins/informer/rpc.go
@@ -2,12 +2,10 @@ package informer
 
 import (
 	"github.com/spiral/roadrunner/v2/pkg/process"
-	"github.com/spiral/roadrunner/v2/plugins/logger"
 )
 
 type rpc struct {
 	srv *Plugin
-	log logger.Logger
 }
 
 // WorkerList contains list of workers.
@@ -18,20 +16,17 @@ type WorkerList struct {
 
 // List all resettable services.
 func (rpc *rpc) List(_ bool, list *[]string) error {
-	rpc.log.Debug("Started List method")
 	*list = make([]string, 0, len(rpc.srv.registry))
 
-	for name := range rpc.srv.registry {
+	// append all plugin names to the output result
+	for name := range rpc.srv.available {
 		*list = append(*list, name)
 	}
-	rpc.log.Debug("list of services", "list", *list)
-	rpc.log.Debug("successfully finished List method")
 	return nil
 }
 
 // Workers state of a given service.
 func (rpc *rpc) Workers(service string, list *WorkerList) error {
-	rpc.log.Debug("started Workers method", "service", service)
 	workers, err := rpc.srv.Workers(service)
 	if err != nil {
 		return err
@@ -40,7 +35,5 @@ func (rpc *rpc) Workers(service string, list *WorkerList) error {
 	// write actual processes
 	list.Workers = workers
 
-	rpc.log.Debug("list of workers", "workers", list.Workers)
-	rpc.log.Debug("successfully finished Workers method")
 	return nil
 }

--- a/plugins/kv/config.go
+++ b/plugins/kv/config.go
@@ -1,5 +1,6 @@
 package kv
 
+// Config represents general storage configuration with keys as the user defined kv-names and values as the drivers
 type Config struct {
 	Data map[string]interface{} `mapstructure:"kv"`
 }

--- a/plugins/kv/drivers/boltdb/plugin.go
+++ b/plugins/kv/drivers/boltdb/plugin.go
@@ -63,3 +63,8 @@ func (s *Plugin) Provide(key string) (kv.Storage, error) {
 func (s *Plugin) Name() string {
 	return PluginName
 }
+
+// Available interface implementation
+func (s *Plugin) Available() bool {
+	return true
+}

--- a/plugins/kv/drivers/memcached/plugin.go
+++ b/plugins/kv/drivers/memcached/plugin.go
@@ -33,6 +33,11 @@ func (s *Plugin) Name() string {
 	return PluginName
 }
 
+// Available interface implementation
+func (s *Plugin) Available() bool {
+	return true
+}
+
 func (s *Plugin) Provide(key string) (kv.Storage, error) {
 	const op = errors.Op("boltdb_plugin_provide")
 	st, err := NewMemcachedDriver(s.log, key, s.cfgPlugin)

--- a/plugins/kv/drivers/memory/plugin.go
+++ b/plugins/kv/drivers/memory/plugin.go
@@ -62,3 +62,8 @@ func (s *Plugin) Provide(key string) (kv.Storage, error) {
 func (s *Plugin) Name() string {
 	return PluginName
 }
+
+// Available interface implementation
+func (s *Plugin) Available() bool {
+	return true
+}

--- a/plugins/kv/storage.go
+++ b/plugins/kv/storage.go
@@ -184,3 +184,8 @@ func (p *Plugin) RPC() interface{} {
 func (p *Plugin) Name() string {
 	return PluginName
 }
+
+// Available interface implementation
+func (p *Plugin) Available() bool {
+	return true
+}


### PR DESCRIPTION
# Reason for This PR

closes #611 

## Description of Changes

- Add `Availabler` interface which returns true if the plugin available in the runtime.
- PHP command to use: `informer.List(bool, array)`. The array will contain all the plugins which are currently available under the user-friendly names (like defined in the config `.rr.yaml` aka: http, logger, metrics, etc).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
