### PR TITLE
fix(bug): RR does not respect `debug` mode when `exec_ttl` is set

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,7 +82,6 @@ jobs:
 
       - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage-ci/summary.txt
           fail_ci_if_error: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ v2.2.0 (11.05.2021)
 ## 🩹 Fixes:
 
 - 🐛 Fix: issue with wrong ordered middlewares (reverse). Now the order is correct.
+- 🐛 Fix: issue when RR fails if a user sets `debug` mode with the `exec_ttl` supervisor option.
 
 ---
 


### PR DESCRIPTION
# Reason for This PR

closes #661 

## Description of Changes

- Add the `execDebugWithTTL` method to the pool to handle cases when the user uses supervisor with `execTTL` in debug mode.
- Update CHANGELOG
- Add tests

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
