### PR TITLE
Fix errors log buffer lost

### DIFF
--- a/pkg/worker_watcher/worker_watcher.go
+++ b/pkg/worker_watcher/worker_watcher.go
@@ -174,10 +174,6 @@ func (ww *workerWatcher) Remove(wb worker.BaseProcess) {
 
 // Push O(1) operation
 func (ww *workerWatcher) Push(w worker.BaseProcess) {
-	if w.State().Value() != worker.StateReady {
-		_ = w.Kill()
-		return
-	}
 	ww.container.Enqueue(w)
 }
 

--- a/pkg/worker_watcher/worker_watcher.go
+++ b/pkg/worker_watcher/worker_watcher.go
@@ -174,6 +174,10 @@ func (ww *workerWatcher) Remove(wb worker.BaseProcess) {
 
 // Push O(1) operation
 func (ww *workerWatcher) Push(w worker.BaseProcess) {
+	if w.State().Value() != worker.StateReady {
+		_ = w.Stop()
+		return
+	}
 	ww.container.Enqueue(w)
 }
 


### PR DESCRIPTION
When I created my own worker process and use the code example for the push error to the rr server for workers

```
    } catch (\Throwable $e) {
        $worker->getWorker()->error((string)$e);
    }
```

I don't see my original error only the next errors:
```
2021-05-26T16:35:46.711+0300    DEBUG   server          server/plugin.go:225    worker destructed       {"pid": 24906}
2021-05-26T16:35:46.725+0300    ERROR   server          server/plugin.go:238    worker_watcher_wait: signal: killed; process_wait: signal: killed
github.com/spiral/roadrunner/v2/plugins/server.(*Plugin).collectEvents
        github.com/spiral/roadrunner/v2@v2.2.1/plugins/server/plugin.go:238
github.com/spiral/roadrunner/v2/pkg/events.(*HandlerImpl).Push
        github.com/spiral/roadrunner/v2@v2.2.1/pkg/events/general.go:37
github.com/spiral/roadrunner/v2/pkg/worker_watcher.(*workerWatcher).wait
        github.com/spiral/roadrunner/v2@v2.2.1/pkg/worker_watcher/worker_watcher.go:235
github.com/spiral/roadrunner/v2/pkg/worker_watcher.(*workerWatcher).addToWatch.func1
        github.com/spiral/roadrunner/v2@v2.2.1/pkg/worker_watcher/worker_watcher.go:260
2021-05-26T16:35:47.278+0300    DEBUG   server          server/plugin.go:223    worker constructed      {"pid": 24965}
```


I think that process killed before error buffer has been clean. 

I also find out that http.pool.debug=true make it works ok but it not good idea for the production proposal

then I try to search for cracking changes and find out that version < 2.0.2 work ok  but 2.0.3+ have this bug

I did code [diff](https://github.com/spiral/roadrunner/compare/v2.0.2...v2.0.3#diff-c6e3ca168ddcd0ddb06724bf5b2107a1e18d4d7ffc8171a6304b5a63158c31d7R86) between this two version 

and find out that it added some if that kill a worker process that has the state not equal to worker.StateReady
but in my case when I send an error invocation to the push, it has worker.stateWorking and if we just kill it I think it lost all the output date before it can be flushed to the main rr stderr or stdout pipes.

#691