### PR TITLE
feat(websockets): bug fixing and polishing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/spiral/roadrunner/v2
 go 1.16
 
 require (
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/alicebob/miniredis/v2 v2.14.5
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
@@ -17,7 +16,7 @@ require (
 	github.com/google/flatbuffers v2.0.0+incompatible
 	github.com/google/uuid v1.2.0
 	github.com/json-iterator/go v1.1.11
-	github.com/klauspost/compress v1.12.2 // indirect
+	github.com/klauspost/compress v1.13.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.10.0
 	github.com/savsgio/gotils v0.0.0-20210316171653-c54912823645 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/klauspost/compress v1.11.8/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+OykW8=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.0 h1:2T7tUoQrQT+fQWdaY5rjWztFGAFwbGD04iPJg90ZiOs=
+github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/pkg/bst/bst.go
+++ b/pkg/bst/bst.go
@@ -52,6 +52,22 @@ func (b *BST) Insert(uuid string, topic string) {
 	}
 }
 
+func (b *BST) Contains(topic string) bool {
+	curr := b
+	for curr != nil {
+		switch {
+		case topic < curr.topic:
+			curr = curr.left
+		case topic > curr.topic:
+			curr = curr.right
+		case topic == curr.topic:
+			return true
+		}
+	}
+
+	return false
+}
+
 func (b *BST) Get(topic string) map[string]struct{} {
 	curr := b
 	for curr != nil {

--- a/pkg/bst/interface.go
+++ b/pkg/bst/interface.go
@@ -8,4 +8,6 @@ type Storage interface {
 	Remove(uuid, topic string)
 	// Get will return all connections associated with the topic
 	Get(topic string) map[string]struct{}
+	// Contains checks if the BST contains a topic
+	Contains(topic string) bool
 }

--- a/pkg/pubsub/interface.go
+++ b/pkg/pubsub/interface.go
@@ -2,6 +2,10 @@ package pubsub
 
 import "github.com/spiral/roadrunner/v2/pkg/pubsub/message"
 
+/*
+This interface is in BETA. It might be changed.
+*/
+
 // PubSub ...
 type PubSub interface {
 	Publisher
@@ -10,15 +14,20 @@ type PubSub interface {
 }
 
 // Subscriber defines the ability to operate as message passing broker.
+// BETA interface
 type Subscriber interface {
 	// Subscribe broker to one or multiple topics.
-	Subscribe(topics ...string) error
+	Subscribe(connectionID string, topics ...string) error
 
 	// Unsubscribe from one or multiply topics
-	Unsubscribe(topics ...string) error
+	Unsubscribe(connectionID string, topics ...string) error
+
+	// Connections returns all connections associated with the particular topic
+	Connections(topic string, ret map[string]struct{})
 }
 
 // Publisher publish one or more messages
+// BETA interface
 type Publisher interface {
 	// Publish one or multiple Channel.
 	Publish(messages []byte) error

--- a/plugins/gzip/plugin.go
+++ b/plugins/gzip/plugin.go
@@ -3,7 +3,7 @@ package gzip
 import (
 	"net/http"
 
-	"github.com/NYTimes/gziphandler"
+	"github.com/klauspost/compress/gzhttp"
 )
 
 const PluginName = "gzip"
@@ -17,7 +17,7 @@ func (g *Plugin) Init() error {
 
 func (g *Plugin) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gziphandler.GzipHandler(next).ServeHTTP(w, r)
+		gzhttp.GzipHandler(next).ServeHTTP(w, r)
 	})
 }
 

--- a/plugins/http/plugin.go
+++ b/plugins/http/plugin.go
@@ -248,6 +248,12 @@ func (p *Plugin) Stop() error {
 
 // ServeHTTP handles connection using set of middleware and pool PSR-7 server.
 func (p *Plugin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		err := r.Body.Close()
+		if err != nil {
+			p.log.Error("body close", "error", err)
+		}
+	}()
 	if headerContainsUpgrade(r) {
 		http.Error(w, "server does not support upgrade header", http.StatusInternalServerError)
 		return

--- a/plugins/redis/plugin.go
+++ b/plugins/redis/plugin.go
@@ -164,14 +164,14 @@ func (p *Plugin) Unsubscribe(connectionID string, topics ...string) error {
 
 	for i := 0; i < len(topics); i++ {
 		// if there are no such topics, we can safely unsubscribe from the redis
-		ssc := p.universalClient.SMembers(context.Background(), topics[i])
-		res, err := ssc.Result()
+		exists := p.universalClient.Exists(context.Background(), topics[i])
+		res, err := exists.Result()
 		if err != nil {
 			return err
 		}
 
 		// if we have associated connections - skip
-		if len(res) > 0 {
+		if res == 1 { // exists means that topic still exists and some other nodes may have connections associated with it
 			continue
 		}
 


### PR DESCRIPTION
# Reason for This PR

- Refactoring

## Description of Changes

- Redis plugin uses its own storage (Sets) to store information about connection without wasting a RR memory.
- Completely remove any storage from the Websockets plugin (only `Subscriber` interface).
- Add a new method to the `Subscriber` interface - `Connections` which returns a hashmap with connections IDs associated with the particular topic.
- Use `sync.Pool` everywhere in the `WorkerPool` to handle big allocations of the hashmaps and byte slices.
- RR2 by benchmarks uses only ~100-120MB of `inuse_space` RAM per 10k WebSocket connections and ~150MB when bombarding with a lot of `Publish` operations.
- Expected (local) throughput for the 1CPU per 10k for Redis broker is around 100k messages per second and ~500k-1M (depending on your system) for `memory` driver.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
