### PR TITLE
feat(metrics): expose HTTP metrics

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,6 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
-
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v2.3.0 (08.06.2021)
   in [schemastore.org](https://github.com/SchemaStore/schemastore/pull/1614))
 - ✏️ `latest` docker image tag supported now (but we strongly recommend using a versioned tag (like `0.2.3`) instead)
 - ✏️ Add new option to the `http` config section: `internal_error_code` to override default (500) internal error code.
+- ✏️ Expose HTTP plugin metrics (workers memory, requests count, requests duration).
 
 ## 🩹 Fixes:
 

--- a/pkg/worker_handler/handler.go
+++ b/pkg/worker_handler/handler.go
@@ -63,7 +63,7 @@ type Handler struct {
 	log              logger.Logger
 	pool             pool.Pool
 	mul              sync.Mutex
-	lsn              events.Listener
+	lsn              []events.Listener
 	internalHTTPCode uint64
 }
 
@@ -82,7 +82,7 @@ func NewHandler(maxReqSize uint64, internalHTTPCode uint64, uploads config.Uploa
 }
 
 // AddListener attaches handler event controller.
-func (h *Handler) AddListener(l events.Listener) {
+func (h *Handler) AddListener(l ...events.Listener) {
 	h.mul.Lock()
 	defer h.mul.Unlock()
 
@@ -192,7 +192,9 @@ func (h *Handler) handleResponse(req *Request, resp *Response, start time.Time) 
 // sendEvent invokes event handler if any.
 func (h *Handler) sendEvent(event interface{}) {
 	if h.lsn != nil {
-		h.lsn(event)
+		for _, l := range h.lsn {
+			l(event)
+		}
 	}
 }
 

--- a/plugins/http/metrics.go
+++ b/plugins/http/metrics.go
@@ -1,0 +1,92 @@
+package http
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	handler "github.com/spiral/roadrunner/v2/pkg/worker_handler"
+)
+
+func (p *Plugin) MetricsCollector() []prometheus.Collector {
+	// p - implements Exporter interface (workers)
+	// other - request duration and count
+	return []prometheus.Collector{p, p.requestsExporter.requestDuration, p.requestsExporter.requestCounter}
+}
+
+func (p *Plugin) metricsCallback(event interface{}) {
+	switch e := event.(type) {
+	case handler.ResponseEvent:
+		p.requestsExporter.requestCounter.With(prometheus.Labels{
+			"status": strconv.Itoa(e.Response.Status),
+		}).Inc()
+
+		p.requestsExporter.requestDuration.With(prometheus.Labels{
+			"status": strconv.Itoa(e.Response.Status),
+		}).Observe(e.Elapsed().Seconds())
+	case handler.ErrorEvent:
+		p.requestsExporter.requestCounter.With(prometheus.Labels{
+			"status": "500",
+		}).Inc()
+
+		p.requestsExporter.requestDuration.With(prometheus.Labels{
+			"status": "500",
+		}).Observe(e.Elapsed().Seconds())
+	}
+}
+
+type workersExporter struct {
+	wm            *prometheus.Desc
+	workersMemory uint64
+}
+
+func newWorkersExporter() *workersExporter {
+	return &workersExporter{
+		wm:            prometheus.NewDesc("rr_http_workers_memory_bytes", "Memory usage by HTTP workers.", nil, nil),
+		workersMemory: 0,
+	}
+}
+
+func (p *Plugin) Describe(d chan<- *prometheus.Desc) {
+	// send description
+	d <- p.workersExporter.wm
+}
+
+func (p *Plugin) Collect(ch chan<- prometheus.Metric) {
+	// get the copy of the processes
+	workers := p.Workers()
+
+	// cumulative RSS memory in bytes
+	var cum uint64
+
+	// collect the memory
+	for i := 0; i < len(workers); i++ {
+		cum += workers[i].MemoryUsage
+	}
+
+	// send the values to the prometheus
+	ch <- prometheus.MustNewConstMetric(p.workersExporter.wm, prometheus.GaugeValue, float64(cum))
+}
+
+type requestsExporter struct {
+	requestCounter  *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+}
+
+func newRequestsExporter() *requestsExporter {
+	return &requestsExporter{
+		requestCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rr_http_request_total",
+				Help: "Total number of handled http requests after server restart.",
+			},
+			[]string{"status"},
+		),
+		requestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "rr_http_request_duration_seconds",
+				Help: "HTTP request duration.",
+			},
+			[]string{"status"},
+		),
+	}
+}

--- a/tests/plugins/metrics/configs/.rr-http-metrics.yaml
+++ b/tests/plugins/metrics/configs/.rr-http-metrics.yaml
@@ -1,0 +1,20 @@
+rpc:
+  listen: tcp://127.0.0.1:6001
+
+server:
+  command: "php ../../psr-worker-bench.php"
+  relay: "pipes"
+
+http:
+  address: 127.0.0.1:13223
+  max_request_size: 1024
+  middleware: [ ]
+  pool:
+    num_workers: 1
+
+metrics:
+  address: localhost:2112
+
+logs:
+  mode: development
+  level: debug


### PR DESCRIPTION
# Reason for This PR

closes: #489 

## Description of Changes

- Expose workers' memory stats via custom exporter implementation.
- Expose request count/duration metrics.
- Tests
-----
Metrics:
![image](https://user-images.githubusercontent.com/8040338/121140538-a06fa480-c842-11eb-92bc-76ddae2565b0.png)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
