### PR TITLE
feat(opt): `inuse_space` and `runtime.newobject` optimizations

### DIFF
--- a/pkg/pool/static_pool_test.go
+++ b/pkg/pool/static_pool_test.go
@@ -588,7 +588,7 @@ func Benchmark_Pool_Echo(b *testing.B) {
 	}
 }
 
-//
+// Benchmark_Pool_Echo_Batched-32          366996          2873 ns/op        1233 B/op          24 allocs/op
 func Benchmark_Pool_Echo_Batched(b *testing.B) {
 	ctx := context.Background()
 	p, err := Initialize(
@@ -619,7 +619,7 @@ func Benchmark_Pool_Echo_Batched(b *testing.B) {
 	wg.Wait()
 }
 
-//
+// Benchmark_Pool_Echo_Replaced-32    	     104/100	  10900218 ns/op	   52365 B/op	     125 allocs/op
 func Benchmark_Pool_Echo_Replaced(b *testing.B) {
 	ctx := context.Background()
 	p, err := Initialize(

--- a/pkg/transport/socket/socket_factory.go
+++ b/pkg/transport/socket/socket_factory.go
@@ -81,7 +81,7 @@ type socketSpawn struct {
 	err error
 }
 
-// SpawnWorker creates Process and connects it to appropriate relay or returns error
+// SpawnWorkerWithTimeout creates Process and connects it to appropriate relay or return an error
 func (f *Factory) SpawnWorkerWithTimeout(ctx context.Context, cmd *exec.Cmd, listeners ...events.Listener) (*worker.Process, error) {
 	const op = errors.Op("factory_spawn_worker_with_timeout")
 	c := make(chan socketSpawn)

--- a/pkg/worker/state.go
+++ b/pkg/worker/state.go
@@ -44,7 +44,7 @@ type StateImpl struct {
 	lastUsed uint64
 }
 
-// Thread safe
+// NewWorkerState initializes a state for the sync.Worker
 func NewWorkerState(value int64) *StateImpl {
 	return &StateImpl{value: value}
 }

--- a/pkg/worker_watcher/container/vec.go
+++ b/pkg/worker_watcher/container/vec.go
@@ -35,9 +35,7 @@ func (v *Vec) Dequeue() (worker.BaseProcess, bool) {
 		return nil, true
 	}
 
-	w := <-v.workers
-
-	return w, false
+	return <-v.workers, false
 }
 
 func (v *Vec) Destroy() {


### PR DESCRIPTION
# Reason for This PR

- Reduce frames and buffers allocations

## Description of Changes

- Use reusable `sync.Pool` pool of objects for hot-paths.
- CPU time for allocations reduced from 29.2% to 23.8% (especially `runtime.newobject`)
- Memory usage for the constantly loaded workers reduced from 18MB to 14MB (for the same payload).
- CPU time in `ns` reduced from `268ns` to `206ns`

Benchmarks were performed on Ryzen 5950X with 64Gb of RAM and 980PRO `nvme` and may vary depending on the hardware (`5.12.10-arch1-1 #1 SMP PREEMPT Thu, 10 Jun 2021 16:34:50 +0000 x86_64 GNU/Linux, XFS fs`)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
