### PR TITLE
fix(allocator): workers were not reallocating when `exec_ttl` was hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ v2.3.1 (_.06.2021)
 
 ## 🩹 Fixes:
 
+- 🐛 Fix: Bug with channel deadlock when `exec_ttl` was used and TTL limit reached [PR](https://github.com/spiral/roadrunner/pull/738)
+- 🐛 Fix: Bug with healthcheck endpoint when workers were mark as invalid and stays is that state until next request [PR](https://github.com/spiral/roadrunner/pull/738)
 - 🐛 Fix: Bugs with `boltdb` storage: [Boom](https://github.com/spiral/roadrunner/issues/717), [Boom](https://github.com/spiral/roadrunner/issues/718), [Boom](https://github.com/spiral/roadrunner/issues/719)
 - 🐛 Fix: Bug with incorrect redis initialization and usage [Bug](https://github.com/spiral/roadrunner/issues/720)
 - 🐛 Fix: Bug, Goridge duplicate error messages [Bug](https://github.com/spiral/goridge/issues/128)

--- a/pkg/pool/static_pool.go
+++ b/pkg/pool/static_pool.go
@@ -174,7 +174,7 @@ func (sp *StaticPool) execWithTTL(ctx context.Context, p payload.Payload) (paylo
 		return sp.execDebugWithTTL(ctx, p)
 	}
 
-	ctxAlloc, cancel := context.WithTimeout(ctx, sp.cfg.AllocateTimeout)
+	ctxAlloc, cancel := context.WithTimeout(context.Background(), sp.cfg.AllocateTimeout)
 	defer cancel()
 	w, err := sp.getWorker(ctxAlloc, op)
 	if err != nil {

--- a/pkg/pool/supervisor_test.go
+++ b/pkg/pool/supervisor_test.go
@@ -108,7 +108,7 @@ func TestSupervisedPool_ExecTTL_TimedOut(t *testing.T) {
 
 	pid := p.Workers()[0].Pid()
 
-	resp, err := p.execWithTTL(context.Background(), payload.Payload{
+	resp, err := p.Exec(payload.Payload{
 		Context: []byte(""),
 		Body:    []byte("foo"),
 	})
@@ -148,7 +148,7 @@ func TestSupervisedPool_Idle(t *testing.T) {
 
 	pid := p.Workers()[0].Pid()
 
-	resp, err := p.execWithTTL(context.Background(), payload.Payload{
+	resp, err := p.Exec(payload.Payload{
 		Context: []byte(""),
 		Body:    []byte("foo"),
 	})
@@ -160,7 +160,7 @@ func TestSupervisedPool_Idle(t *testing.T) {
 	time.Sleep(time.Second * 5)
 
 	// worker should be marked as invalid and reallocated
-	_, err = p.execWithTTL(context.Background(), payload.Payload{
+	_, err = p.Exec(payload.Payload{
 		Context: []byte(""),
 		Body:    []byte("foo"),
 	})

--- a/pkg/worker/sync_worker.go
+++ b/pkg/worker/sync_worker.go
@@ -111,6 +111,15 @@ func (tw *SyncWorkerImpl) ExecWithTTL(ctx context.Context, p payload.Payload) (p
 			return
 		}
 
+		if tw.process.State().Value() != StateWorking {
+			tw.process.State().RegisterExec()
+			c <- wexec{
+				payload: rsp,
+				err:     nil,
+			}
+			return
+		}
+
 		tw.process.State().Set(StateReady)
 		tw.process.State().RegisterExec()
 

--- a/pkg/worker_watcher/container/interface.go
+++ b/pkg/worker_watcher/container/interface.go
@@ -1,6 +1,8 @@
 package container
 
-import "github.com/spiral/roadrunner/v2/pkg/worker"
+import (
+	"github.com/spiral/roadrunner/v2/pkg/worker"
+)
 
 // Vector interface represents vector container
 type Vector interface {

--- a/pkg/worker_watcher/container/interface.go
+++ b/pkg/worker_watcher/container/interface.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/spiral/roadrunner/v2/pkg/worker"
 )
 
@@ -9,7 +11,7 @@ type Vector interface {
 	// Enqueue used to put worker to the vector
 	Enqueue(worker.BaseProcess)
 	// Dequeue used to get worker from the vector
-	Dequeue() (worker.BaseProcess, bool)
+	Dequeue(ctx context.Context) (worker.BaseProcess, error)
 	// Destroy used to stop releasing the workers
 	Destroy()
 }

--- a/pkg/worker_watcher/container/vec.go
+++ b/pkg/worker_watcher/container/vec.go
@@ -38,13 +38,11 @@ func (v *Vec) Dequeue(ctx context.Context) (worker.BaseProcess, error) {
 		return nil, errors.E(errors.WatcherStopped)
 	}
 
-	for {
-		select {
-		case w := <-v.workers:
-			return w, nil
-		case <-ctx.Done():
-			return nil, errors.E(ctx.Err(), errors.NoFreeWorkers)
-		}
+	select {
+	case w := <-v.workers:
+		return w, nil
+	case <-ctx.Done():
+		return nil, errors.E(ctx.Err(), errors.NoFreeWorkers)
 	}
 }
 

--- a/tests/plugins/http/configs/.rr-http-supervised-pool.yaml
+++ b/tests/plugins/http/configs/.rr-http-supervised-pool.yaml
@@ -2,17 +2,13 @@ rpc:
   listen: tcp://127.0.0.1:15432
 server:
   command: "php ../../http/client.php echo pipes"
-  user: ""
-  group: ""
-  env:
-    "RR_HTTP": "true"
   relay: "pipes"
   relay_timeout: "20s"
 
 http:
   address: 127.0.0.1:18888
   max_request_size: 1024
-  middleware: [ "" ]
+  middleware: []
   uploads:
     forbid: [ ".php", ".exe", ".bat" ]
   trusted_subnets: [ "10.0.0.0/8", "127.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "::1/128", "fc00::/7", "fe80::/10" ]

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -1481,6 +1481,8 @@ func informerTestAfter(t *testing.T) {
 
 	assert.NotZero(t, workerPid)
 
+	time.Sleep(time.Second * 5)
+
 	err = client.Call("informer.Workers", "http", &list)
 	assert.NoError(t, err)
 	assert.Len(t, list.Workers, 1)

--- a/tests/psr-worker-slow.php
+++ b/tests/psr-worker-slow.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @var Goridge\RelayInterface $relay
+ */
+use Spiral\Goridge;
+use Spiral\RoadRunner;
+
+ini_set('display_errors', 'stderr');
+require __DIR__ . "/vendor/autoload.php";
+
+$worker = new RoadRunner\Worker(new Goridge\StreamRelay(STDIN, STDOUT));
+$psr7 = new RoadRunner\Http\PSR7Worker(
+    $worker,
+    new \Nyholm\Psr7\Factory\Psr17Factory(),
+    new \Nyholm\Psr7\Factory\Psr17Factory(),
+    new \Nyholm\Psr7\Factory\Psr17Factory()
+);
+
+while ($req = $psr7->waitRequest()) {
+    try {
+        $resp = new \Nyholm\Psr7\Response();
+        sleep(mt_rand(1,20));
+        $resp->getBody()->write("hello world");
+
+        $psr7->respond($resp);
+    } catch (\Throwable $e) {
+        $psr7->getWorker()->error((string)$e);
+    }
+}


### PR DESCRIPTION
# Reason for This PR

closes #737 
closes #734 

## Description of Changes

- Fix deadlock in the `worker_watcher`.
- Fix incorrect workers state handling for the `healthcheck` endpoint. Now workers not in the `Working` state automatically stop by the supervisor and state properly updated.

This is the simplified version of the bug:
```golang
package main

import (
	"context"
	"time"
)

func main() {
	s := NewStr()

	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
	s.put()
	for i := 0; i < 1000; i++ {
		go s.foo(ctx)
	}
	cancel()

	s.put()
	s.put()
	s.put()

	s.foo(context.Background())
}

type str struct {
	v chan struct{}
}

func NewStr() *str {
	return &str{v: make(chan struct{}, 5)}
}

func (s *str) put() {
	s.v <- struct{}{}
}

func (s *str) foo(ctx context.Context) {
	r := make(chan struct{}, 1)
	go func() {
		time.Sleep(time.Second * 5)
		sss := <-s.v
		r <- sss
	}()

	select {
	case <-ctx.Done():
		return
	case _ = <-r:
		return
	}
}
```

Obviously, after `cancel`, channel `r` became without reading part (deadlock). The whole operation became locked after `exec_ttl` was hit (`ctx.Done()`).

The correct `foo` method should be as following:
```golang
func (s *str) foo(ctx context.Context) {
	select {
	case <-ctx.Done():
		return
	case <-s.v:
		return
	}
}
```
Local performance growth about 5-10% (reduced the allocation of goroutines, lower GC load). 

![image](https://user-images.githubusercontent.com/8040338/123489146-09fcfa80-d61a-11eb-9c19-f09224f256d9.png)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
