### PR TITLE
fix(amqp): type casting for the amqp headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ v2.4.0 (_.08.2021)
 
 - ✏️ Long-awaited, reworked `Jobs` plugin with pluggable drivers. Now you can allocate/destroy pipelines in the runtime.
   Drivers included in the initial release: `RabbitMQ (0-9-1)`, `SQS v2`, `beanstalk`, `ephemeral` and local queue powered by the `boltdb`. [PR](https://github.com/spiral/roadrunner/pull/726)
-- Support for the IPv6 (`tcp|http(s)|empty [::]:port`, `tcp|http(s)|empty [::1]:port`, `tcp|http(s)|empty :// [0:0:0:0:0:0:0:1]:port`) for RPC, HTTP and other plugins. [RFC](https://datatracker.ietf.org/doc/html/rfc2732#section-2)
+- ✏️ Support for the IPv6 (`tcp|http(s)|empty [::]:port`, `tcp|http(s)|empty [::1]:port`, `tcp|http(s)|empty :// [0:0:0:0:0:0:0:1]:port`) for RPC, HTTP and other plugins. [RFC](https://datatracker.ietf.org/doc/html/rfc2732#section-2)
+- ✏️ Support for the Docker images via GitHub packages.
+- ✏️ Go 1.17 support.
+
 ## 🩹 Fixes:
 
 - 🐛 Fix: fixed bug with goroutines waiting on the internal worker's container channel, [issue](https://github.com/spiral/roadrunner/issues/750).

--- a/plugins/amqp/amqpjobs/item.go
+++ b/plugins/amqp/amqpjobs/item.go
@@ -224,15 +224,25 @@ func (c *consumer) unpack(d amqp.Delivery) (*Item, error) {
 		}
 	}
 
-	if _, ok := d.Headers[job.RRDelay].(int64); ok {
-		item.Options.Delay = d.Headers[job.RRDelay].(int64)
+	if t, ok := d.Headers[job.RRDelay]; ok {
+		switch t.(type) {
+		case int, int16, int32, int64:
+			item.Options.Delay = t.(int64)
+		default:
+			c.log.Warn("unknown delay type", "want:", "int, int16, int32, int64", "actual", t)
+		}
 	}
 
-	if _, ok := d.Headers[job.RRPriority]; !ok {
+	if t, ok := d.Headers[job.RRPriority]; !ok {
 		// set pipe's priority
 		item.Options.Priority = c.priority
 	} else {
-		item.Options.Priority = d.Headers[job.RRPriority].(int64)
+		switch t.(type) {
+		case int, int16, int32, int64:
+			item.Options.Priority = t.(int64)
+		default:
+			c.log.Warn("unknown priority type", "want:", "int, int16, int32, int64", "actual", t)
+		}
 	}
 
 	return item, nil


### PR DESCRIPTION
# Reason for This PR

- ref: https://github.com/spiral/jobs/issues/49
- Check all possible (for the amqp.Table) integer types.

## Description of Changes

- Add types check for the `RRDelay` and `RRPriority` to accept any of the `int`, `int16`, `int32`, or `int64`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
