### PR TITLE
feat(logger): Zap fields can be used as arguments to logger

### DIFF
--- a/plugins/logger/zap_adapter.go
+++ b/plugins/logger/zap_adapter.go
@@ -19,8 +19,8 @@ func NewZapAdapter(zapLogger *zap.Logger) *ZapAdapter {
 }
 
 func separateFields(keyVals []interface{}) ([]zap.Field, []interface{}) {
-	fields := []zap.Field{}
-	pairedKeyVals := []interface{}{}
+	var fields []zap.Field
+	var pairedKeyVals []interface{}
 
 	for key := range keyVals {
 		switch value := keyVals[key].(type) {

--- a/plugins/logger/zap_adapter.go
+++ b/plugins/logger/zap_adapter.go
@@ -18,18 +18,21 @@ func NewZapAdapter(zapLogger *zap.Logger) *ZapAdapter {
 	}
 }
 
-func separateFields(keyVals []interface{}) (fields []zap.Field, individualKeyVals []interface{}) {
-	for _, value := range keyVals {
-		switch value := value.(type) {
+func separateFields(keyVals []interface{}) ([]zap.Field, []interface{}) {
+	fields := []zap.Field{}
+	pairedKeyVals := []interface{}{}
+
+	for key := range keyVals {
+		switch value := keyVals[key].(type) {
 		case zap.Field:
 			fields = append(fields, value)
 		case core.ObjectMarshaler:
 			fields = append(fields, zap.Inline(value))
 		default:
-			individualKeyVals = append(individualKeyVals, value)
+			pairedKeyVals = append(pairedKeyVals, value)
 		}
 	}
-	return
+	return fields, pairedKeyVals
 }
 
 func (log *ZapAdapter) fields(keyvals []interface{}) []zap.Field {

--- a/plugins/logger/zap_adapter.go
+++ b/plugins/logger/zap_adapter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+	core "go.uber.org/zap/zapcore"
 )
 
 type ZapAdapter struct {
@@ -17,13 +18,30 @@ func NewZapAdapter(zapLogger *zap.Logger) *ZapAdapter {
 	}
 }
 
+func separateFields(keyVals []interface{}) (fields []zap.Field, individualKeyVals []interface{}) {
+	for _, value := range keyVals {
+		switch value := value.(type) {
+		case zap.Field:
+			fields = append(fields, value)
+		case core.ObjectMarshaler:
+			fields = append(fields, zap.Inline(value))
+		default:
+			individualKeyVals = append(individualKeyVals, value)
+		}
+	}
+	return
+}
+
 func (log *ZapAdapter) fields(keyvals []interface{}) []zap.Field {
+	// separate any zap fields from other structs
+	zapFields, keyvals := separateFields(keyvals)
+
 	// we should have even number of keys and values
 	if len(keyvals)%2 != 0 {
 		return []zap.Field{zap.Error(fmt.Errorf("odd number of keyvals pairs: %v", keyvals))}
 	}
 
-	fields := make([]zap.Field, 0, len(keyvals)/2)
+	fields := make([]zap.Field, 0, len(keyvals)/2+len(zapFields))
 	for i := 0; i < len(keyvals); i += 2 {
 		key, ok := keyvals[i].(string)
 		if !ok {
@@ -31,6 +49,8 @@ func (log *ZapAdapter) fields(keyvals []interface{}) []zap.Field {
 		}
 		fields = append(fields, zap.Any(key, keyvals[i+1]))
 	}
+	// add all the fields
+	fields = append(fields, zapFields...)
 
 	return fields
 }

--- a/tests/plugins/logger/logger_test.go
+++ b/tests/plugins/logger/logger_test.go
@@ -357,3 +357,74 @@ func httpEcho(t *testing.T) {
 	err = r.Body.Close()
 	assert.NoError(t, err)
 }
+
+func TestMarshalObjectLogging(t *testing.T) {
+	container, err := endure.NewContainer(nil, endure.RetryOnFail(true), endure.SetLogLevel(endure.ErrorLevel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// config plugin
+	vp := &config.Viper{}
+	vp.Path = "configs/.rr-file-logger.yaml"
+	vp.Prefix = "rr"
+
+	err = container.RegisterAll(
+		vp,
+		&Plugin{},
+		&logger.ZapLogger{},
+	)
+	assert.NoError(t, err)
+
+	err = container.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errCh, err := container.Serve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// stop by CTRL+C
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	stopCh := make(chan struct{}, 1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case e := <-errCh:
+				assert.NoError(t, e.Error)
+				assert.NoError(t, container.Stop())
+				return
+			case <-c:
+				err = container.Stop()
+				assert.NoError(t, err)
+				return
+			case <-stopCh:
+				assert.NoError(t, container.Stop())
+				return
+			}
+		}
+	}()
+
+	time.Sleep(time.Second * 2)
+
+	f, err := os.ReadFile("test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, string(f), "Example marshaller error")
+	assert.Equal(t, 4, strings.Count(string(f), "Example marshaller error"))
+
+	_ = os.Remove("test.log")
+
+	stopCh <- struct{}{}
+	wg.Wait()
+}

--- a/tests/plugins/logger/plugin.go
+++ b/tests/plugins/logger/plugin.go
@@ -43,7 +43,7 @@ func (p1 *Plugin) Serve() chan error {
 	p1.log.Debug("error", field)
 	p1.log.Warn("error", field)
 
-	marshalledObject := Loggable{}
+	marshalledObject := &Loggable{}
 
 	p1.log.Error("error", marshalledObject)
 	p1.log.Info("error", marshalledObject)

--- a/tests/plugins/logger/plugin.go
+++ b/tests/plugins/logger/plugin.go
@@ -6,11 +6,21 @@ import (
 	"github.com/spiral/errors"
 	"github.com/spiral/roadrunner/v2/plugins/config"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
+	"go.uber.org/zap"
+	core "go.uber.org/zap/zapcore"
 )
 
 type Plugin struct {
 	config config.Configurer
 	log    logger.Logger
+}
+
+type Loggable struct {
+}
+
+func (l *Loggable) MarshalLogObject(encoder core.ObjectEncoder) error {
+	encoder.AddString("error", "Example marshaller error")
+	return nil
 }
 
 func (p1 *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
@@ -25,6 +35,20 @@ func (p1 *Plugin) Serve() chan error {
 	p1.log.Info("error", "test", errors.E(errors.Str("test")))
 	p1.log.Debug("error", "test", errors.E(errors.Str("test")))
 	p1.log.Warn("error", "test", errors.E(errors.Str("test")))
+
+	field := zap.String("error", "Example field error")
+
+	p1.log.Error("error", field)
+	p1.log.Info("error", field)
+	p1.log.Debug("error", field)
+	p1.log.Warn("error", field)
+
+	marshalledObject := Loggable{}
+
+	p1.log.Error("error", marshalledObject)
+	p1.log.Info("error", marshalledObject)
+	p1.log.Debug("error", marshalledObject)
+	p1.log.Warn("error", marshalledObject)
 
 	p1.log.Error("error", "test")
 	p1.log.Info("error", "test")


### PR DESCRIPTION
# Reason for This PR

When logging in a plugin it would be useful to take advantage of the underlying Zap library, in this case being able to create fields that define the key and the value to go to output or to even use object marshalling to apply multiple keys/interfaces to the output.

At current if a [Zap field object](https://pkg.go.dev/go.uber.org/zap#Object) is passed as an argument, you must provide a key with it to then be processed as an interface otherwise an error is thrown that an uneven number of arguments have been provided.

With this you can now do something like:

```go
import (
	"go.uber.org/zap"
)

field := zap.String("error", "Example field error")

log.Error("error", field)
```

and get an output like:

```json
{"message":"error", "error": "Example field error"}
```

Equally the following code would produce the same output:

```go
import (
	"go.uber.org/zap"
)

type Loggable struct {
}

func (l *Loggable) MarshalLogObject(encoder core.ObjectEncoder) error {
	encoder.AddString("error", "Example marshaller error")
	return nil
}

marshalledObject := &Loggable{}

log.Error("error", marshalledObject)
```

My apologies if the PR is not in the correct format. This was something I worked on for myself but felt might be useful to the wider community. I noticed there isn't a contributing guide beyond the PR and am not 100% on the process or the best way to add to a release.

Any feedback on if this is wanted by requires some work would be greatly appreciated.

## Description of Changes

* no breaking changes
* using debug, error, info etc. on the logger with a [Zap field](https://pkg.go.dev/go.uber.org/zap#Object) or an Object that implements Zap's object marshalling will be separated from the key/values provided an appended to the values send to the zap adapter.
* adds the calls to the tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
