### PR TITLE
feat(http) Allows for custom request/response logging

### DIFF
--- a/plugins/http/interface.go
+++ b/plugins/http/interface.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	"net/http"
+
+	handler "github.com/spiral/roadrunner/v2/pkg/worker_handler"
+	"github.com/spiral/roadrunner/v2/plugins/logger"
+)
+
+// Middleware interface
+type Middleware interface {
+	Middleware(f http.Handler) http.Handler
+}
+
+type LogHandler func(ev handler.ResponseEvent, log logger.Logger)
+
+type ResponseEventHandler interface {
+	SetCallbackHandler(handler LogHandler)
+}

--- a/plugins/http/plugin.go
+++ b/plugins/http/plugin.go
@@ -128,7 +128,7 @@ func (p *Plugin) logCallback(event interface{}) {
 	}
 }
 
-func (p *Plugin) SetCallbackHandler(handler LogHandler)  {
+func (p *Plugin) SetCallbackHandler(handler LogHandler) {
 	p.callbackLogHandler = handler
 }
 

--- a/tests/plugins/http/configs/.rr-custom-logging.yaml
+++ b/tests/plugins/http/configs/.rr-custom-logging.yaml
@@ -1,0 +1,24 @@
+rpc:
+  listen: tcp://127.0.0.1:6001
+
+server:
+  command: "php ../../http/client.php echo pipes"
+  relay: "pipes"
+  relay_timeout: "20s"
+
+http:
+  address: 127.0.0.1:12078
+  max_request_size: 1024
+  middleware: [ ]
+  uploads:
+    forbid: [ ".php", ".exe", ".bat" ]
+  trusted_subnets: [ "10.0.0.0/8", "127.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "::1/128", "fc00::/7", "fe80::/10" ]
+  pool:
+    num_workers: 2
+    max_jobs: 0
+    allocate_timeout: 60s
+    destroy_timeout: 60s
+logs:
+  mode: development
+  level: debug
+

--- a/tests/plugins/http/plugin_logging.go
+++ b/tests/plugins/http/plugin_logging.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	handler "github.com/spiral/roadrunner/v2/pkg/worker_handler"
+	"github.com/spiral/roadrunner/v2/plugins/http"
+	"github.com/spiral/roadrunner/v2/plugins/logger"
+)
+
+type PluginLogging struct {
+}
+
+func (p1 *PluginLogging) Init(reHandler http.ResponseEventHandler) error {
+	reHandler.SetCallbackHandler(func(ev handler.ResponseEvent, logger logger.Logger) {
+		logger.Debug("test of custom logging", "url", ev.Request.URI)
+	})
+
+	return nil
+}
+
+func (p1 *PluginLogging) Name() string {
+	return "http_test.plugin_logging"
+}


### PR DESCRIPTION
# Reason for This PR

Adds a mechanism to hook into the logging of request callback to customise the logging of HTTP requests in the http plugin.

## Description of Changes

By default nothing has changed except that now if someone wants to they can customise the logging of HTTP requests to add additional details. For example there might be headers etc that should be added to the logging output.

This can be done by implementing a plugin that gets the `ResponseEventHandler` service and sets the callback to handle the logging.

An example of this would be:

```go
package http

import (
	handler "github.com/spiral/roadrunner/v2/pkg/worker_handler"
	"github.com/spiral/roadrunner/v2/plugins/http"
	"github.com/spiral/roadrunner/v2/plugins/logger"
)

type PluginLogging struct {
}

func (p1 *PluginLogging) Init(reHandler http.ResponseEventHandler) error {
	reHandler.SetCallbackHandler(func(ev handler.ResponseEvent, logger logger.Logger) {
		logger.Debug("test of custom logging", "url", ev.Request.URI)
	})

	return nil
}

func (p1 *PluginLogging) Name() string {
	return "http_test.plugin_logging"
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
