### PR TITLE
fix(jobs, memory): start `jobs` `in-memory` driver automatically if the user consumes it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
     "cSpell.words": [
         "goridge",
+        "goroutines",
         "jobsv",
+        "pluggable",
         "prefetch",
         "stretchr"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cSpell.words": [
+        "goridge",
+        "jobsv",
+        "prefetch",
+        "stretchr"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
-## v2.4.1 (10.09.2021)
+## v2.4.1 (13.09.2021)
 
 ## 🩹 Fixes:
 
 -   🐛 Fix: bug with not-idempotent call to the `attributes.Init`.
+-   🐛 Fix: memory jobs driver behavior. Now memory driver starts consuming automatically if the user consumes the pipeline in the configuration.
 
 ## v2.4.0 (02.09.2021)
 

--- a/tests/plugins/jobs/jobs_memory_test.go
+++ b/tests/plugins/jobs/jobs_memory_test.go
@@ -107,7 +107,7 @@ func TestMemoryInit(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(time.Second * 3)
+	time.Sleep(time.Second * 1)
 	stopCh <- struct{}{}
 	wg.Wait()
 }
@@ -229,7 +229,7 @@ func TestMemoryPauseResume(t *testing.T) {
 	mockLogger.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	mockLogger.EXPECT().Info("pipeline active", "pipeline", "test-local-2", "start", gomock.Any(), "elapsed", gomock.Any()).Times(1)
-	mockLogger.EXPECT().Info("pipeline active", "pipeline", "test-local", "start", gomock.Any(), "elapsed", gomock.Any()).Times(3)
+	mockLogger.EXPECT().Info("pipeline active", "pipeline", "test-local", "start", gomock.Any(), "elapsed", gomock.Any()).Times(2)
 
 	mockLogger.EXPECT().Info("pipeline paused", "pipeline", "test-local", "driver", "memory", "start", gomock.Any(), "elapsed", gomock.Any()).Times(1)
 
@@ -301,7 +301,6 @@ func TestMemoryPauseResume(t *testing.T) {
 
 	time.Sleep(time.Second * 3)
 
-	t.Run("Resume", resumePipes("test-local"))
 	t.Run("Pause", pausePipelines("test-local"))
 	t.Run("pushToDisabledPipe", pushToDisabledPipe("test-local"))
 	t.Run("Resume", resumePipes("test-local"))


### PR DESCRIPTION
# Reason for This PR

- Consume option for the in-memory plugin was a no-op. A user had to resume pipe manually.

## Description of Changes

- Made the `in-memory` driver behavior like all other jobs drivers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
