### PR TITLE
feat(worker_watcher): make a `Destroy` context useful

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v2 # Action page: <https://github.com/golangci/golangci-lint-action>
         with:
-          version: v1.42 # without patch version
+          version: v1.43 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --timeout=10m


### PR DESCRIPTION
# Reason for This PR

- Unused context in the worker watcher's `Destroy` method.

## Description of Changes

- Kill everything after `<-ctx.Done`.
- Update golangci-lint to `v1.43`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
