### PR TITLE
fix(vector): deadlock on the channel send

### DIFF
--- a/worker_watcher/worker_watcher.go
+++ b/worker_watcher/worker_watcher.go
@@ -112,10 +112,6 @@ func (ww *workerWatcher) Take(ctx context.Context) (worker.BaseProcess, error) {
 			return nil, errors.E(op, err)
 		}
 
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-
 		switch w.State().Value() {
 		// return only workers in the Ready state
 		// check first


### PR DESCRIPTION
# Reason for This PR

- ? https://github.com/spiral/roadrunner-plugins/issues/109

## Description of Changes

- non blocking channel send
- In some very rare cases, when several workers get TTL-ed, it may lead to the situation, where the first reallocated worker might be pushed into the channel right after we search for the TTL-ed worker in the channel. This is only possible when the channel is full of TTL-ed workers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
